### PR TITLE
Remove aws validation

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -246,12 +246,6 @@ module Shoryuken
         logger.warn "No worker supplied for '#{queue}'" unless Shoryuken.workers.include? queue
       end
 
-      if Shoryuken.options[:aws][:access_key_id].nil? && Shoryuken.options[:aws][:secret_access_key].nil?
-        if ENV['AWS_ACCESS_KEY_ID'].nil? && ENV['AWS_SECRET_ACCESS_KEY'].nil?
-          raise ArgumentError, 'No AWS credentials supplied'
-        end
-      end
-
       initialize_aws
 
       Shoryuken.queues.uniq.each do |queue|


### PR DESCRIPTION
Current validations makes it impossible to use shoryuken together with EC2 instances with configured IAM roles\groups. These EC2 instances do not have aws credentials. Access to aws services is managed by IAM config. This behaviour is supported by default in aws-sdk gem, so there is no need to have additional validation in shoryuken.
