### PR TITLE
ActiveJob support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](shoryuken.jpg)
 
-Shoryuken _sho-ryu-ken_ is a super efficient [AWS SQS](https://aws.amazon.com/sqs/) thread based message processor.
+Shoryuken _sho-ryu-ken_ is a super-efficient [AWS SQS](https://aws.amazon.com/sqs/) thread-based message processor.
 
 [![Build Status](https://travis-ci.org/phstc/shoryuken.svg)](https://travis-ci.org/phstc/shoryuken)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,32 @@ If you load Rails, and assuming your workers are located in the `app/workers` di
 
 This feature works for Rails 4+, but needs to be confirmed for older versions.
 
+#### ActiveJob Support
+
+Yes, Shoryuken supports ActiveJob! This means that you can put your jobs in processor-agnostic `ActiveJob::Base` subclasses, and change processors whenever you want (or better yet, switch to Shoryuken from another processor easily!).
+
+It works as expected. Just put your job in `app/jobs`. Here's an example:
+
+```ruby
+class ProcessPhotoJob < ActiveJob::Base
+  queue_as :default
+
+  rescue_from ActiveJob::DeserializationError do |e|
+    Shoryuken.logger.error "#{e.inspect}. It was probably deleted before processing."
+  end
+
+  def perform(photo)
+    photo.process_image!
+  end
+end
+```
+
+Delayed mailers, ActiveRecord serialization, etc. all work.
+
+See [ActiveJob docs](http://edgeguides.rubyonrails.org/active_job_basics.html) for more info.
+
+*Note:* When queueing jobs to be performed in the future (e.g when setting the `wait` or `wait_until` ActiveJob options), SQS limits the amount of time to 15 minutes. Shoryuken will raise an exception if you attempt to schedule a job further into the future than this limit.
+
 ### Start Shoryuken
 
 ```shell

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -94,3 +94,5 @@ module Shoryuken
     end
   end
 end
+
+require 'shoryuken/extensions/active_job_adapter' if defined?(::ActiveJob)

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -243,8 +243,10 @@ module Shoryuken
     def validate!
       raise ArgumentError, 'No queues supplied' if Shoryuken.queues.empty?
 
-      Shoryuken.queues.each do |queue|
-        logger.warn "No worker supplied for '#{queue}'" unless Shoryuken.workers.include? queue
+      unless defined?(::ActiveJob)
+        Shoryuken.queues.each do |queue|
+          logger.warn "No worker supplied for '#{queue}'" unless Shoryuken.workers.include? queue
+        end
       end
 
       if Shoryuken.options[:aws][:access_key_id].nil? && Shoryuken.options[:aws][:secret_access_key].nil?

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -77,6 +77,7 @@ module Shoryuken
         ::Rails::Application.initializer "shoryuken.eager_load" do
           ::Rails.application.config.eager_load = true
         end
+        require 'shoryuken/extensions/active_job_adapter' if defined?(::ActiveJob)
         require File.expand_path("config/environment.rb")
       end
 

--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -1,0 +1,43 @@
+# ActiveJob docs: http://edgeguides.rubyonrails.org/active_job_basics.html
+# Example adapters ref: https://github.com/rails/rails/tree/master/activejob/lib/active_job/queue_adapters
+# Ref: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/extensions/active_record.rb
+# Multiple queues ref: https://github.com/rails/rails/blob/master/activejob/lib/active_job/queue_adapters/sneakers_adapter.rb
+
+require 'shoryuken'
+
+module ActiveJob
+  module QueueAdapters
+    # == Shoryuken adapter for Active Job
+    #
+    # Shoryuken ("sho-ryu-ken") is a super-efficient AWS SQS thread based message processor.
+    #
+    # Read more about Shoryuken {here}[https://github.com/phstc/shoryuken].
+    #
+    # To use Shoryuken set the queue_adapter config to +:shoryuken+.
+    #
+    #   Rails.application.config.active_job.queue_adapter = :shoryuken
+    class ShoryukenAdapter
+      class << self
+        def enqueue(job) #:nodoc:
+          # TODO use job.queue_name
+          JobWrapper.perform_async(job.serialize)
+        end
+
+        def enqueue_at(job, timestamp) #:nodoc:
+          # TODO use job.queue_name
+          JobWrapper.perform_at(timestamp, job.serialize)
+        end
+      end
+
+      class JobWrapper #:nodoc:
+        include Shoryuken::Worker
+
+        shoryuken_options queue: 'default', body_parser: :json
+
+        def perform(sqs_msg, hash)
+          Base.execute hash
+        end
+      end
+    end
+  end
+end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -173,7 +173,7 @@ module Shoryuken
       # get/remove the first queue in the list
       queue = @queues.shift
 
-      unless defined?(::ActiveJob) || Shoryuken.workers.include?(queue)
+      unless Shoryuken.workers.include? queue
         # when no worker registered pause the queue to avoid endless recursion
 
         logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered"

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -172,16 +172,14 @@ module Shoryuken
       # get/remove the first queue in the list
       queue = @queues.shift
 
-      unless defined?(::ActiveJob)
-        unless Shoryuken.workers.include? queue
-          # when no worker registered pause the queue to avoid endless recursion
+      unless defined?(::ActiveJob) || Shoryuken.workers.include?(queue)
+        # when no worker registered pause the queue to avoid endless recursion
 
-          logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered"
+        logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered"
 
-          after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
+        after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
 
-          return next_queue
-        end
+        return next_queue
       end
 
       # add queue back to the end of the list

--- a/lib/shoryuken/middleware/server/timing.rb
+++ b/lib/shoryuken/middleware/server/timing.rb
@@ -5,7 +5,10 @@ module Shoryuken
         include Util
 
         def call(worker, queue, sqs_msg, body)
-          class_name = if defined?(::ActiveJob) && body['job_class'].present?
+          class_name = if defined?(::ActiveJob) \
+                        && !sqs_msg.is_a?(Array) \
+                        && sqs_msg.message_attributes['shoryuken_class'] \
+                        && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s
                          "ActiveJob/#{body['job_class'].constantize}"
                        else
                          worker.class.to_s

--- a/lib/shoryuken/middleware/server/timing.rb
+++ b/lib/shoryuken/middleware/server/timing.rb
@@ -5,7 +5,12 @@ module Shoryuken
         include Util
 
         def call(worker, queue, sqs_msg, body)
-          Shoryuken::Logging.with_context("#{worker.class.to_s}/#{queue}/#{sqs_msg.id}") do
+          class_name = if defined?(::ActiveJob) && body['job_class'].present?
+                         "ActiveJob/#{body['job_class'].constantize}"
+                       else
+                         worker.class.to_s
+                       end
+          Shoryuken::Logging.with_context("#{class_name}/#{queue}/#{sqs_msg.id}") do
             begin
               started_at = Time.now
 

--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
 
   spec.add_dependency "aws-sdk-v1"
-  spec.add_dependency "celluloid", ">= 0.16.0"
+  spec.add_dependency "celluloid", "~> 0.16.0"
 end


### PR DESCRIPTION
This is working for me in development currently. This is similar to the code @phstc posted here: https://github.com/phstc/shoryuken/issues/4#issuecomment-62056681, with a few fixes and improvements.

Notes:
- Queue pausing/sleeping is disabled when ActiveJob is present. This is needed because the workers are dynamically-defined, so the queues would be paused indefinitely and jobs wouldn't be processed.
- Logging middleware altered to use the ActiveJob subclass name (instead of wrapper class name) for better logging.
- It would be good to add tests, but I'm not sure where to start with this yet. All current tests pass.
- Altered Celluloid dependency to track the minor version, in case of breaking changes.