### PR TITLE
ActiveJob: skip pausing if workers aren't registered

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -173,7 +173,7 @@ module Shoryuken
       # get/remove the first queue in the list
       queue = @queues.shift
 
-      unless Shoryuken.workers.include? queue
+      unless defined?(::ActiveJob) || Shoryuken.workers.include?(queue)
         # when no worker registered pause the queue to avoid endless recursion
 
         logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered"


### PR DESCRIPTION
Turns out this is required after all, and I had it in there for a reason :)

So the issue is that ActiveJob workers get registered at runtime *only on the server process*. As far as the CLI processor is concerned, it doesn't know that there are workers registered to run the jobs, and thus the queues are paused and never resumed.

Because we resolve the worker classes at runtime, the CLI can still find and execute them.

Let me know if you can think of a better way to handle this, but it seems to be necessary to never pause the queues for ActiveJob purposes, as things are now.