### PR TITLE
fix activejob implementation

### DIFF
--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -25,7 +25,7 @@ module ActiveJob
         def enqueue_at(job, timestamp) #:nodoc:
           register_worker!(job)
 
-          delay = timestamp - Time.current.to_f
+          delay = (timestamp - Time.current.to_f).round
           raise 'The maximum allowed delay is 15 minutes' if delay > 15.minutes
 
           Shoryuken::Client.send_message(job.queue_name, job.serialize, delay_seconds: delay,

--- a/lib/shoryuken/middleware/server/timing.rb
+++ b/lib/shoryuken/middleware/server/timing.rb
@@ -5,7 +5,7 @@ module Shoryuken
         include Util
 
         def call(worker, queue, sqs_msg, body)
-          Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg)}/#{queue}/#{sqs_msg.id}") do
+          Shoryuken::Logging.with_context("#{worker_name(worker.class, sqs_msg, body)}/#{queue}/#{sqs_msg.id}") do
             begin
               started_at = Time.now
 

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -24,7 +24,7 @@ module Shoryuken
       end.to_a
     end
 
-    def worker_name(worker_class, sqs_msg)
+    def worker_name(worker_class, sqs_msg, body = nil)
       if defined?(::ActiveJob) \
           && !sqs_msg.is_a?(Array) \
           && sqs_msg.message_attributes['shoryuken_class'] \


### PR DESCRIPTION
fixes undefined local variable body in `worker_name` method and delay seconds in float causing malformed input error from sqs