### PR TITLE
Initialize logger before loading Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ You can tell Shoryuken to load your Rails application by passing the `-R` or `--
 
 If you load Rails, and assuming your workers are located in the `app/workers` directory, they will be auto-loaded. This means you don't need to require them explicitly with `-r`.
 
+For middleware and other configuration, you might want to create an initializer:
+
+```ruby
+Shoryuken.configure_server do |config|
+  # Replace Rails logger so messages are logged wherever Shoryuken is logging
+  # Note: this entire block is only run by the processor, so we don't overwrite
+  #       the logger when the app is running as usual.
+  Rails.logger = Shoryuken::Logging.logger
+
+  config.server_middleware do |chain|
+    chain.add Shoryuken::MyMiddleware
+  end
+end
+```
+
+*Note:* In the above case, since we are replacing the Rails logger, it's desired that this initializer runs before other initializers (in case they themselves use the logger). Since by Rails conventions initializers are executed in alphabetical order, this can be achieved by prepending the initializer filename with `00_` (assuming no other initializers alphabetically precede this one).
+
 This feature works for Rails 4+, but needs to be confirmed for older versions.
 
 #### ActiveJob Support

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -24,9 +24,9 @@ module Shoryuken
 
       setup_options(args) do |cli_options|
         # this needs to happen before configuration is parsed, since it may depend on Rails env
+        initialize_logger(cli_options)
         load_rails if cli_options[:rails]
       end
-      initialize_logger
       require_workers
       validate!
       patch_deprecated_workers!
@@ -234,10 +234,10 @@ module Shoryuken
       end
     end
 
-    def initialize_logger
-      Shoryuken::Logging.initialize_logger(Shoryuken.options[:logfile]) if Shoryuken.options[:logfile]
+    def initialize_logger(options = Shoryuken.options)
+      Shoryuken::Logging.initialize_logger(options[:logfile]) if options[:logfile]
 
-      Shoryuken.logger.level = Logger::DEBUG if Shoryuken.options[:verbose]
+      Shoryuken.logger.level = Logger::DEBUG if options[:verbose]
     end
 
     def validate!


### PR DESCRIPTION
This is necessary in order to replace the standard Rails logger with the Shoryuken logger (need to initialize the logger before loading Rails, so that it is available to Rails initializers).

Why would we want replace the Rails logger? So that what is normally logged in Rails (via the usual `logger.info` and `Rails.logger.info` shows up in the Shoryuken logfile.