### PR TITLE
Shoryuken.on_start callback added

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -79,6 +79,12 @@ module Shoryuken
       @@default_worker_options = options
     end
 
+    def on_start(&block)
+      @start_callback = block
+    end
+
+    attr_reader :start_callback
+
     private
 
     def default_server_middleware

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -83,7 +83,11 @@ module Shoryuken
       @start_callback = block
     end
 
-    attr_reader :start_callback
+    def on_stop(&block)
+      @stop_callback = block
+    end
+
+    attr_reader :start_callback, :stop_callback
 
     private
 

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -40,7 +40,10 @@ module Shoryuken
       require 'shoryuken/launcher'
       @launcher = Shoryuken::Launcher.new
 
-      Shoryuken.start_callback.call if Shoryuken.start_callback
+      if Shoryuken.start_callback
+        logger.info "Calling Shoryuken.on_start block"
+        Shoryuken.start_callback.call
+      end
 
       begin
         launcher.run

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -40,6 +40,8 @@ module Shoryuken
       require 'shoryuken/launcher'
       @launcher = Shoryuken::Launcher.new
 
+      Shoryuken.start_callback.call if Shoryuken.start_callback
+
       begin
         launcher.run
 

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -32,6 +32,11 @@ module Shoryuken
       watchdog('Manager#stop died') do
         @done = true
 
+        if Shoryuken.stop_callback
+          logger.info "Calling Shoryuken.on_stop block"
+          Shoryuken.stop_callback.call
+        end
+
         @fetcher.terminate if @fetcher.alive?
 
         logger.info { "Shutting down #{@ready.size} quiet workers" }


### PR DESCRIPTION
I wanted to be able to execute some code only when shoryuken had booted celluloid, so I added a hook in:

```ruby
Shoryuken.on_start do
  # do some more stuff to celluloid, like setting up new SupervisionGroups
end
```