### PR TITLE
message_attributes is nil on comcast/cmb

### DIFF
--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -27,6 +27,7 @@ module Shoryuken
     def worker_name(worker_class, sqs_msg, body = nil)
       if defined?(::ActiveJob) \
           && !sqs_msg.is_a?(Array) \
+          && sqs_msg.message_attributes \
           && sqs_msg.message_attributes['shoryuken_class'] \
           && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s
 


### PR DESCRIPTION
I develop against a local instance of https://github.com/Comcast/cmb which doesn't currently support message attributes. It returns ```nil``` for ```Aws::SQS::Message#message_attributes``` which breaks ```worker_name``` which assumes that message_attributes will always be a hash. A very edge case I suppose, but it does no harm to fix it.