### PR TITLE
process_died should not log if no reason provided

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -66,7 +66,7 @@ module Shoryuken
 
     def processor_died(processor, reason)
       watchdog("Manager#processor_died died") do
-        logger.error "Process died, reason: #{reason}"
+        logger.error "Process died, reason: #{reason}" unless reason.to_s.empty?
 
         @busy.delete processor
 


### PR DESCRIPTION
Looks like the previous commit where I made this change was accidental reverted?