### PR TITLE
Bandwidth fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ You can tell Shoryuken to load your Rails application by passing the `-R` or `--
 
 If you load Rails, and assuming your workers are located in the `app/workers` directory, they will be auto-loaded. This means you don't need to require them explicitly with `-r`.
 
+For middleware and other configuration, you might want to create an initializer:
+
+```ruby
+Shoryuken.configure_server do |config|
+  # Replace Rails logger so messages are logged wherever Shoryuken is logging
+  # Note: this entire block is only run by the processor, so we don't overwrite
+  #       the logger when the app is running as usual.
+  Rails.logger = Shoryuken::Logging.logger
+
+  config.server_middleware do |chain|
+    chain.add Shoryuken::MyMiddleware
+  end
+end
+```
+
+*Note:* In the above case, since we are replacing the Rails logger, it's desired that this initializer runs before other initializers (in case they themselves use the logger). Since by Rails conventions initializers are executed in alphabetical order, this can be achieved by prepending the initializer filename with `00_` (assuming no other initializers alphabetically precede this one).
+
 This feature works for Rails 4+, but needs to be confirmed for older versions.
 
 ### Start Shoryuken

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -24,9 +24,9 @@ module Shoryuken
 
       setup_options(args) do |cli_options|
         # this needs to happen before configuration is parsed, since it may depend on Rails env
+        initialize_logger(cli_options)
         load_rails if cli_options[:rails]
       end
-      initialize_logger
       require_workers
       validate!
       patch_deprecated_workers!
@@ -233,10 +233,10 @@ module Shoryuken
       end
     end
 
-    def initialize_logger
-      Shoryuken::Logging.initialize_logger(Shoryuken.options[:logfile]) if Shoryuken.options[:logfile]
+    def initialize_logger(options = Shoryuken.options)
+      Shoryuken::Logging.initialize_logger(options[:logfile]) if options[:logfile]
 
-      Shoryuken.logger.level = Logger::DEBUG if Shoryuken.options[:verbose]
+      Shoryuken.logger.level = Logger::DEBUG if options[:verbose]
     end
 
     def validate!

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -13,7 +13,7 @@ module Shoryuken
       # AWS limits the batch size by 10
       limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
 
-      options = Shoryuken.options[:aws][:receive_message].to_h
+      options = Shoryuken.options[:aws][:receive_message].to_h.dup
       options[:limit] = limit
       options[:message_attribute_names] ||= []
       options[:message_attribute_names] << 'shoryuken_class'


### PR DESCRIPTION
Fix for https://github.com/phstc/shoryuken/issues/44

What was happening was that `shoryuken_class` was being added to the `message_attribute_names` of `options` every time Fetcher's `receive_message` was called, leading to larger-and-larger request sizes.

Now, we simply `dup` the options every time to start with a clean slate.

BTW, I cherry picked a commit that already is merged into master here: https://github.com/phstc/shoryuken/pull/33/files (I am working from our "stable" based on 0.0.4, since we are using this in production). As this commit is already there, the only file of interest here is `fetcher.rb`.

I thought Github was smart enough to spot the similarities, but guess not.