### PR TITLE
Call `configure_server` only on server

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -57,7 +57,7 @@ module Shoryuken
     #   end
     # end
     def configure_server
-      yield self
+      yield self if server?
     end
 
     def server_middleware
@@ -90,6 +90,10 @@ module Shoryuken
           m.add Middleware::Server::ActiveRecord
         end
       end
+    end
+
+    def server?
+      defined?(Shoryuken::CLI)
     end
   end
 end


### PR DESCRIPTION
`Shryuken.configure_server` block should only be executed on server. The issue I was having is that the content of this block was also being executed by my Rails initializer, which meant if I did anything funny like redirecting Rails logger output to Shoryuken in there (this is good for the Shoryuken CLI), my Rails app would also do the same thing (not good).