### PR TITLE
Specify what queue does not exist

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -267,7 +267,7 @@ module Shoryuken
         begin
           Shoryuken::Client.queues queue
         rescue AWS::SQS::Errors::NonExistentQueue => e
-          raise ArgumentError, "Queue '#{queue}' does not exist"
+          raise ArgumentError, "AWS Queue '#{queue}' does not exist."
         rescue => e
           raise
         end


### PR DESCRIPTION
Before the message was ambiguous, and didn't specify it was AWS queue that wasn't there.