### PR TITLE
use the queue passed to process for auto_visibility_timeout

### DIFF
--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -37,11 +37,11 @@ module Shoryuken
 
     def auto_visibility_timeout(queue, sqs_msg, worker_class)
       if worker_class.auto_visibility_timeout?
-        timer = every(worker_class.visibility_timeout_heartbeat) do
+        timer = every(worker_class.visibility_timeout_heartbeat(queue)) do
           begin
-            logger.debug "Extending message #{worker_name(worker_class, sqs_msg)}/#{queue}/#{sqs_msg.id} visibility timeout to #{worker_class.extended_visibility_timeout}"
+            logger.debug "Extending message #{worker_name(worker_class, sqs_msg)}/#{queue}/#{sqs_msg.id} visibility timeout to #{worker_class.extended_visibility_timeout(queue)}"
 
-            sqs_msg.visibility_timeout = worker_class.extended_visibility_timeout
+            sqs_msg.visibility_timeout = worker_class.extended_visibility_timeout(queue)
           rescue => e
             logger.error "Could not auto extend the message #{worker_class}/#{queue}/#{sqs_msg.id} visibility timeout. Error: #{e.message}"
           end

--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -51,12 +51,12 @@ module Shoryuken
         !!get_shoryuken_options['auto_visibility_timeout']
       end
 
-      def visibility_timeout_heartbeat
-        extended_visibility_timeout - 5
+      def visibility_timeout_heartbeat(queue)
+        extended_visibility_timeout(queue) - 5
       end
 
-      def extended_visibility_timeout
-        Shoryuken::Client.visibility_timeout(get_shoryuken_options['queue'])
+      def extended_visibility_timeout(queue)
+        Shoryuken::Client.visibility_timeout(queue)
       end
 
       def get_shoryuken_options # :nodoc:

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -115,6 +115,23 @@ describe 'Shoryuken::Worker' do
     end
   end
 
+  describe '.visibility_timeout' do
+    before do
+      allow(Shoryuken::Client).to receive(:visibility_timeout).with('queue1').and_return(60)
+      allow(Shoryuken::Client).to receive(:visibility_timeout).with('queue2').and_return(120)
+    end
+
+    it 'returns the seconds to extend visibility timeout for a queue' do
+      expect(TestWorker.extended_visibility_timeout('queue1')).to eq 60
+      expect(TestWorker.extended_visibility_timeout('queue2')).to eq 120
+    end
+
+    it 'returns how often to extend visibility timeout for a queue' do
+      expect(TestWorker.visibility_timeout_heartbeat('queue1')).to eq 55
+      expect(TestWorker.visibility_timeout_heartbeat('queue2')).to eq 115
+    end
+  end
+
   describe '.server_middleware' do
     before do
       class FakeMiddleware


### PR DESCRIPTION
Fixes issue #52 

When processing an sqs message, the processor should look up the visibility timeout for the queue where the message came from, rather than rely on the default queue of the worker it fetches to process the message.