### PR TITLE
update aws dependencies

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "nokogiri"
   spec.add_development_dependency "dotenv"
 
-  spec.add_dependency "aws-sdk-core", "2.0.21"
-  spec.add_dependency "aws-sdk-resources", "2.0.21.pre"
+  spec.add_dependency "aws-sdk-core", "2.0.22"
+  spec.add_dependency "aws-sdk-resources", "2.0.22"
   spec.add_dependency "celluloid", "~> 0.16.0"
 end


### PR DESCRIPTION
if you want to use the latest gem 'aws-sdk', '~> 2' and shoryuken it returned 
```
Bundler could not find compatible versions for gem "aws-sdk-resources":
  In Gemfile:
    aws-sdk (~> 2) ruby depends on
      aws-sdk-resources (= 2.0.22) ruby

    shoryuken (>= 0) ruby depends on
      aws-sdk-resources (2.0.21.pre)
```
so i updated the dependencies to the required version.