### PR TITLE
Convert message body to JSON string explicitly.

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -12,6 +12,8 @@ module Shoryuken
           string_value: self.to_s,
           data_type: 'String'
         }
+
+        body = JSON.dump(body) if body.is_a?(Hash)
         options[:message_body] = body
 
         Shoryuken::Client.queues(get_shoryuken_options['queue']).send_message(options)

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -66,6 +66,19 @@ describe 'Shoryuken::Worker' do
       TestWorker.perform_async('message')
     end
 
+    it 'enqueues a message given as hash' do
+      expect(sqs_queue).to receive(:send_message).with(
+        message_attributes: {
+          'shoryuken_class' => {
+            string_value: TestWorker.to_s,
+            data_type: 'String'
+          }
+        },
+        message_body: '{"field":"part1","other_field":"part2"}')
+
+      TestWorker.perform_async(field: 'part1', other_field: 'part2')
+    end
+
     it 'enqueues a message with options' do
       expect(sqs_queue).to receive(:send_message).with(
         delay_seconds: 60,


### PR DESCRIPTION
I found the example 

```
MyWorker.perform_async(field: 'test', other_field: 'other')
```

from here https://github.com/phstc/shoryuken/wiki/Sending-a-message to fail with this exception:

```
ArgumentError - expected params[:message_body] to be a string:
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/param_validator.rb:24:in `validate!'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/param_validator.rb:9:in `validate!'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/plugins/param_validation.rb:21:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/plugins/param_conversion.rb:22:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/request.rb:70:in `send_request'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-core-2.0.21/lib/seahorse/client/base.rb:215:in `block (2 levels) in define_operation_methods'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-resources-2.0.21.pre/lib/aws-sdk-resources/request.rb:24:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-resources-2.0.21.pre/lib/aws-sdk-resources/operations.rb:41:in `call'
        /my-project/vendor/ruby/2.1.0/gems/aws-sdk-resources-2.0.21.pre/lib/aws-sdk-resources/operation_methods.rb:19:in `block in add_operation'
        /my-project/vendor/ruby/2.1.0/bundler/gems/shoryuken-d6fa3638372c/lib/shoryuken/worker.rb:19:in `perform_async'
```

Explicitly converting it to JSON appears to fix it, as messages are enqueued and dequeued correctly, as far as I can tell.

Could be that this fix is located better at `Shoryuken::Topic`?!