### PR TITLE
Don't fail on unsupported signals, e.g. on Windows.

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -20,8 +20,12 @@ module Shoryuken
       self_read, self_write = IO.pipe
 
       %w[INT TERM USR1 USR2 TTIN].each do |sig|
-        trap sig do
-          self_write.puts(sig)
+        begin
+          trap sig do
+            self_write.puts(sig)
+          end
+        rescue ArgumentError
+          puts "Signal #{sig} not supported"
         end
       end
 


### PR DESCRIPTION
Shameless imitation of how its done in Sidekiq https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb#L55-L63

Basically it won't fail if a signal is not supported, but only report the issue.