### PR TITLE
Support ActiveJob queue name prefixes

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -30,6 +30,7 @@ module Shoryuken
 
   @@queues          = []
   @@worker_registry = DefaultWorkerRegistry.new
+  @@active_job_queue_name_prefixing = false
 
   class << self
     def options
@@ -54,6 +55,14 @@ module Shoryuken
 
     def worker_registry
       @@worker_registry
+    end
+
+    def active_job_queue_name_prefixing
+      @@active_job_queue_name_prefixing
+    end
+
+    def active_job_queue_name_prefixing=(prefixing)
+      @@active_job_queue_name_prefixing = prefixing
     end
 
     # Shoryuken.configure_server do |config|


### PR DESCRIPTION
I took a shot at #57, because I was also looking for a more elegant solution than just adding the prefixes manually in the config file. Having a discrepancy between the queue name in the workers and the config seemed odd. ActiveJob seems to want the ultimately resolved names of queues to be transparent, so I think this should honor that.

It's pretty straightforward, but I honestly had no idea how to add tests that need a Rail environment to get loaded. I'm happy to write them if someone can point me in the right direction, though.

Because this would likely be a breaking change for anyone with a defined Active Job prefix, it must be opt-in, so I added a configuration that could be set in an initializer:

```
# config/initializers/shoryuken.rb
Shoryuken.active_job_queue_name_prefixing = true
```