### PR TITLE
Support IAM role based access while providing non-credentials related AWS config

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -58,11 +58,13 @@ module Shoryuken
         shoryuken_keys.include?(k)
       end
 
+      # assume credentials based authentication
       credentials = Aws::Credentials.new(
         aws_options.delete(:access_key_id),
         aws_options.delete(:secret_access_key))
 
-      aws_options = aws_options.merge(credentials: credentials)
+      # but only if the configuration options have valid values
+      aws_options = aws_options.merge(credentials: credentials) if credentials.set?
 
       if (callback = Shoryuken.aws_initialization_callback)
         Shoryuken.logger.info 'Calling Shoryuken.on_aws_initialization block'


### PR DESCRIPTION
The proposed change allows the configuration of non-credentials related AWS config options without forcing users to provide credentials, thereby enabling role-based access.

**Background**

The AWS SDK supports `Aws::InstanceProfileCredentials` if no other credentials are provided and the SDK is being used from an EC2 instance.  Unfortunately, providing `Aws.config[:credentials]` with an instance of `Aws::Credentials` with `nil` or empty credentials disables this functionality.

Admittedly, I have yet to find exactly where in the SDK this is taking place as `Aws:: CredentialProviderChain` does not appear to reference `Aws.config[:credentials]`.  The request signers also appear to use the result of `Aws::CredentialProviderChain#resolve` instead of referencing `Aws.config[:credentials]`.  I am probably just overlooking something obvious at this point though.