### PR TITLE
Shoryuken.yml with environment section

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -41,7 +41,8 @@ module Shoryuken
 
       return {} unless path
 
-      YAML.load(ERB.new(IO.read(path)).result).deep_symbolize_keys
+      yml_configs = YAML.load(ERB.new(IO.read(path)).result).deep_symbolize_keys
+      yml_configs[Rails.env.to_sym] || yml_configs if options[:rails]
     end
 
     def initialize_aws

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -41,8 +41,12 @@ module Shoryuken
 
       return {} unless path
 
-      yml_configs = YAML.load(ERB.new(IO.read(path)).result).deep_symbolize_keys
-      yml_configs[Rails.env.to_sym] || yml_configs if options[:rails]
+      env_section(YAML.load(ERB.new(IO.read(path)).result)).deep_symbolize_keys
+    end
+
+    def env_section(yml)
+      env = Rails.env if options[:rails] || ENV['environment']
+      yml[env] || yml
     end
 
     def initialize_aws


### PR DESCRIPTION
This enables to use the same shoryuken.yml to manage all environments vars

Sample:
```yml
default: &default
  concurrency: 20
  delay: 5

development:
  <<: *default
  aws:
    access_key_id:      <%= ENV['AWS_ACCESS_KEY_ID'] %>
    secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
    region:             <%= ENV['AWS_REGION'] %>
    receive_message:    # See http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Queue.html#receive_messages-instance_method
      wait_time_seconds: 5
  queues:
    # [ queue_name, priority ]
    - [<%= ENV['QUEUE_ONE'] %>, 2]

production:
  <<: *default
  # Using IAM Role.
  queues:
    # [ queue_name, priority ]
    - [<%= ENV['QUEUE_TWO'] %>, 2]
```

