### PR TITLE
reduce noise in logs by dropping some manager log severities to debug

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -58,7 +58,7 @@ module Shoryuken
 
     def processor_done(queue, processor)
       watchdog('Manager#processor_done died') do
-        logger.info "Process done for '#{queue}'"
+        logger.debug "Process done for '#{queue}'"
 
         @threads.delete(processor.object_id)
         @busy.delete processor
@@ -90,7 +90,7 @@ module Shoryuken
 
     def assign(queue, sqs_msg)
       watchdog('Manager#assign died') do
-        logger.info "Assigning #{sqs_msg.message_id}"
+        logger.debug "Assigning #{sqs_msg.message_id}"
 
         processor = @ready.pop
         @busy << processor


### PR DESCRIPTION
I think the current logging is a bit verbose for ```:info```. I imagine 99% of users will be using either the built-in timing middleware or one of their own, so they'll be seeing success/failure log per message anyway. We don't need to write out another 2 log lines per successful message.