### PR TITLE
Removed use of defer

### DIFF
--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -19,12 +19,10 @@ module Shoryuken
       timer = auto_visibility_timeout(queue, sqs_msg, worker.class)
 
       begin
-        defer do
-          body = get_body(worker.class, sqs_msg)
+        body = get_body(worker.class, sqs_msg)
 
-          worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
-            worker.perform(sqs_msg, body)
-          end
+        worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
+          worker.perform(sqs_msg, body)
         end
 
         @manager.async.processor_done(queue, current_actor)


### PR DESCRIPTION
Following [sidekiq's lead][1] this is no longer necessary. It also means that `Shoryuken::Shutdown` will be raised on the worker thread which, in turn means it is possible to create middleware that respond to it.

---

What lead me here was looking for a way to react to `Shoryuken::Shutdown` within middleware. This is so that I can set a low visibility timeout which means the messages will become visible much quicker for reprocessing.

The use of `defer` means that the worker is executing in a second thread and so `Shoryuken::Shutdown` was being sent to its parent instead.

As an aside, using less threads will likely be better for performance too.

The only downside I can imagine for this is that any custom middleware with a blanket `rescue` will start catching these previously uncatchable errors. However, it's pretty easy to ignore them if this is a problem with:

```ruby
rescue Shoryuken::Shutdown
  raise
rescue => e
  # whatever
```

 [1]: https://github.com/mperham/sidekiq/issues/919