### PR TITLE
Extracted queue polling strategy

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -19,6 +19,7 @@ require 'shoryuken/middleware/server/exponential_backoff_retry'
 require 'shoryuken/middleware/server/timing'
 require 'shoryuken/sns_arn'
 require 'shoryuken/topic'
+require 'shoryuken/polling'
 
 module Shoryuken
   DEFAULTS = {
@@ -26,7 +27,8 @@ module Shoryuken
     queues: [],
     aws: {},
     delay: 0,
-    timeout: 8
+    timeout: 8,
+    polling_strategy: Polling::WeightedRoundRobin,
   }
 
   @@queues = []

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -9,18 +9,6 @@ module Shoryuken
       @manager = manager
     end
 
-    def receive_messages(queue, limit)
-      # AWS limits the batch size by 10
-      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
-
-      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
-      options[:max_number_of_messages] = limit
-      options[:message_attribute_names] = %w(All)
-      options[:attribute_names] = %w(All)
-
-      Shoryuken::Client.queues(queue).receive_messages options
-    end
-
     def fetch(queue, available_processors)
       watchdog('Fetcher#fetch died') do
         started_at = Time.now
@@ -28,23 +16,23 @@ module Shoryuken
         logger.debug { "Looking for new messages in '#{queue}'" }
 
         begin
-          batch = Shoryuken.worker_registry.batch_receive_messages?(queue)
+          batch = Shoryuken.worker_registry.batch_receive_messages?(queue.name)
           limit = batch ? FETCH_LIMIT : available_processors
 
           if (sqs_msgs = Array(receive_messages(queue, limit))).any?
             logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
 
             if batch
-              @manager.async.assign(queue, patch_sqs_msgs!(sqs_msgs))
+              @manager.async.assign(queue.name, patch_sqs_msgs!(sqs_msgs))
             else
-              sqs_msgs.each { |sqs_msg| @manager.async.assign(queue, sqs_msg) }
+              sqs_msgs.each { |sqs_msg| @manager.async.assign(queue.name, sqs_msg) }
             end
 
-            @manager.async.rebalance_queue_weight!(queue)
+            @manager.async.messages_present(queue)
           else
             logger.debug { "No message found for '#{queue}'" }
 
-            @manager.async.pause_queue!(queue)
+            @manager.async.queue_empty(queue)
           end
 
           @manager.async.dispatch
@@ -57,10 +45,23 @@ module Shoryuken
           @manager.async.dispatch
         end
       end
-
     end
 
     private
+
+    def receive_messages(queue, limit)
+      # AWS limits the batch size by 10
+      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
+
+      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
+      options[:max_number_of_messages] = limit
+      options[:message_attribute_names] = %w(All)
+      options[:attribute_names] = %w(All)
+
+      options.merge!(queue.options)
+
+      Shoryuken::Client.queues(queue.name).receive_messages options
+    end
 
     def patch_sqs_msgs!(sqs_msgs)
       sqs_msgs.instance_eval do

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -1,4 +1,5 @@
 require 'shoryuken/processor'
+require 'shoryuken/polling'
 require 'shoryuken/fetcher'
 
 module Shoryuken
@@ -12,7 +13,7 @@ module Shoryuken
 
     def initialize(condvar)
       @count  = Shoryuken.options[:concurrency] || 25
-      @queues = Shoryuken.queues.dup.uniq
+      @polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
       @finished = condvar
 
       @done = false
@@ -99,22 +100,18 @@ module Shoryuken
       end
     end
 
-    def rebalance_queue_weight!(queue)
-      watchdog('Manager#rebalance_queue_weight! died') do
-        if (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
-          logger.info { "Increasing '#{queue}' weight to #{current + 1}, max: #{original}" }
-
-          @queues << queue
-        end
+    def messages_present(queue)
+      watchdog('Manager#messages_present died') do
+        @polling_strategy.messages_present(queue)
       end
     end
 
-    def pause_queue!(queue)
-      return if !@queues.include?(queue) || Shoryuken.options[:delay].to_f <= 0
+    def queue_empty(queue)
+      return if Shoryuken.options[:delay].to_f <= 0
 
       logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty" }
 
-      @queues.delete(queue)
+      @polling_strategy.pause(queue)
 
       after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
     end
@@ -123,7 +120,7 @@ module Shoryuken
     def dispatch
       return if stopped?
 
-      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{unparse_queues(@queues)}" }
+      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{@polling_strategy.active_queues}" }
 
       if @ready.empty?
         logger.debug { 'Pausing fetcher, because all processors are busy' }
@@ -157,50 +154,33 @@ module Shoryuken
     def restart_queue!(queue)
       return if stopped?
 
-      unless @queues.include? queue
-        logger.debug { "Restarting '#{queue}'" }
+      @polling_strategy.restart(queue)
 
-        @queues << queue
+      if @fetcher_paused
+        logger.debug { 'Restarting fetcher' }
 
-        if @fetcher_paused
-          logger.debug { 'Restarting fetcher' }
+        @fetcher_paused = false
 
-          @fetcher_paused = false
-
-          dispatch
-        end
+        dispatch
       end
-    end
-
-    def current_queue_weight(queue)
-      queue_weight(@queues, queue)
-    end
-
-    def original_queue_weight(queue)
-      queue_weight(Shoryuken.queues, queue)
-    end
-
-    def queue_weight(queues, queue)
-      queues.count { |q| q == queue }
     end
 
     def next_queue
-      return nil if @queues.empty?
-
       # get/remove the first queue in the list
-      queue = @queues.shift
+      queue = @polling_strategy.next_queue
 
-      unless defined?(::ActiveJob) ||  !Shoryuken.worker_registry.workers(queue).empty?
+      return nil unless queue
+
+      if queue && (not defined?(::ActiveJob) and Shoryuken.worker_registry.workers(queue.name).empty?)
         # when no worker registered pause the queue to avoid endless recursion
         logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered" }
 
+        @polling_strategy.pause(queue)
+
         after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
 
-        return next_queue
+        queue = next_queue
       end
-
-      # add queue back to the end of the list
-      @queues << queue
 
       queue
     end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -107,13 +107,13 @@ module Shoryuken
     end
 
     def queue_empty(queue)
-      return if Shoryuken.options[:delay].to_f <= 0
+      return if delay <= 0
 
-      logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty" }
+      logger.debug { "Pausing '#{queue}' for #{delay} seconds, because it's empty" }
 
       @polling_strategy.pause(queue)
 
-      after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
+      after(delay) { async.restart_queue!(queue) }
     end
 
 
@@ -145,6 +145,10 @@ module Shoryuken
 
     private
 
+    def delay
+      Shoryuken.options[:delay].to_f
+    end
+
     def build_processor
       processor = Processor.new_link(current_actor)
       processor.proxy_id = processor.object_id
@@ -171,13 +175,13 @@ module Shoryuken
 
       return nil unless queue
 
-      if queue && (not defined?(::ActiveJob) and Shoryuken.worker_registry.workers(queue.name).empty?)
+      if queue && (!defined?(::ActiveJob) && Shoryuken.worker_registry.workers(queue.name).empty?)
         # when no worker registered pause the queue to avoid endless recursion
-        logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered" }
+        logger.debug { "Pausing '#{queue}' for #{delay} seconds, because no workers registered" }
 
         @polling_strategy.pause(queue)
 
-        after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
+        after(delay) { async.restart_queue!(queue) }
 
         queue = next_queue
       end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -57,7 +57,7 @@ module Shoryuken
           @queues == other
         else
           if other.respond_to?(:active_queues)
-            self.active_queues == other.active_queues
+            active_queues == other.active_queues
           else
             false
           end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -1,0 +1,82 @@
+module Shoryuken
+  module Polling
+    QueueConfiguration = Struct.new(:name, :options) do
+      def ==(other)
+        case other
+        when String
+          if options.empty?
+            name == other
+          else
+            false
+          end
+        else
+          super
+        end
+      end
+    end
+
+    class WeightedRoundRobin
+      include Util
+
+      def initialize(queues)
+        @initial_queues = queues
+        @queues = queues.dup.uniq
+      end
+
+      def active_queues
+        unparse_queues(@queues)
+      end
+
+      def next_queue
+        queue = @queues.shift
+        @queues << queue
+        QueueConfiguration.new(queue, {})
+      end
+
+      def messages_present(queue)
+        return unless (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
+
+        logger.info "Increasing '#{queue}' weight to #{current + 1}, max: #{original}"
+        @queues << queue
+      end
+
+      def pause(queue)
+        return unless @queues.delete(queue)
+        logger.debug "Paused '#{queue}'"
+      end
+
+      def restart(queue)
+        return if @queues.include?(queue)
+        logger.debug "Restarting '#{queue}'"
+        @queues << queue
+      end
+
+      def ==(other)
+        case other
+        when Array
+          @queues == other
+        else
+          if other.respond_to?(:active_queues)
+            self.active_queues == other.active_queues
+          else
+            false
+          end
+        end
+      end
+
+      private
+
+      def current_queue_weight(queue)
+        queue_weight(@queues, queue)
+      end
+
+      def original_queue_weight(queue)
+        queue_weight(@initial_queues, queue)
+      end
+
+      def queue_weight(queues, queue)
+        queues.count { |q| q == queue }
+      end
+    end
+  end
+end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -1,6 +1,10 @@
 module Shoryuken
   module Polling
     QueueConfiguration = Struct.new(:name, :options) do
+      def hash
+        name.hash
+      end
+
       def ==(other)
         case other
         when String
@@ -13,6 +17,8 @@ module Shoryuken
           super
         end
       end
+
+      alias_method :eql?, :==
     end
 
     class WeightedRoundRobin

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -27,7 +27,7 @@ describe Shoryuken::Fetcher do
     it 'calls pause when no message' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).and_return([])
 
-      expect(manager).to receive(:queue_empty).with(queue_name)
+      expect(manager).to receive(:queue_empty).with(queue_config)
       expect(manager).to receive(:dispatch)
 
       subject.fetch(queue_config, 1)
@@ -36,7 +36,7 @@ describe Shoryuken::Fetcher do
     it 'assigns messages' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_config)
       expect(manager).to receive(:assign).with(queue_name, sqs_msg)
       expect(manager).to receive(:dispatch)
 
@@ -48,7 +48,7 @@ describe Shoryuken::Fetcher do
 
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_config)
       expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
       expect(manager).to receive(:dispatch)
 
@@ -61,7 +61,7 @@ describe Shoryuken::Fetcher do
       it 'ignores batch' do
         allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-        expect(manager).to receive(:messages_present).with(queue_name)
+        expect(manager).to receive(:messages_present).with(queue_config)
         expect(manager).to receive(:assign).with(queue_name, sqs_msg)
         expect(manager).to receive(:dispatch)
 

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -6,6 +6,7 @@ describe Shoryuken::Fetcher do
   let(:manager)    { double Shoryuken::Manager }
   let(:queue)      { double Shoryuken::Queue }
   let(:queue_name) { 'default' }
+  let(:queue_config) { Shoryuken::Polling::QueueConfiguration.new(queue_name, {}) }
 
   let(:sqs_msg) do
     double Shoryuken::Message,
@@ -26,20 +27,20 @@ describe Shoryuken::Fetcher do
     it 'calls pause when no message' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).and_return([])
 
-      expect(manager).to receive(:pause_queue!).with(queue_name)
+      expect(manager).to receive(:queue_empty).with(queue_name)
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 1)
+      subject.fetch(queue_config, 1)
     end
 
     it 'assigns messages' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_name)
       expect(manager).to receive(:assign).with(queue_name, sqs_msg)
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 5)
+      subject.fetch(queue_config, 5)
     end
 
     it 'assigns messages in batch' do
@@ -47,11 +48,11 @@ describe Shoryuken::Fetcher do
 
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_name)
       expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 5)
+      subject.fetch(queue_config, 5)
     end
 
     context 'when worker not found' do
@@ -60,11 +61,11 @@ describe Shoryuken::Fetcher do
       it 'ignores batch' do
         allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-        expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+        expect(manager).to receive(:messages_present).with(queue_name)
         expect(manager).to receive(:assign).with(queue_name, sqs_msg)
         expect(manager).to receive(:dispatch)
 
-        subject.fetch(queue_name, 5)
+        subject.fetch(queue_config, 5)
       end
     end
   end

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -20,11 +20,11 @@ describe Shoryuken::Manager do
       Shoryuken.queues << queue1
       Shoryuken.queues << queue2
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue1, queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
 
-      subject.pause_queue!(queue1)
+      subject.queue_empty(queue1)
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
     end
 
     it 'increases weight' do
@@ -39,18 +39,18 @@ describe Shoryuken::Manager do
       Shoryuken.queues << queue1
       Shoryuken.queues << queue2
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue1, queue2]
-      subject.pause_queue!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
+      subject.queue_empty(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1, queue1, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1, queue1]
     end
 
     it 'adds queue back' do
@@ -69,12 +69,12 @@ describe Shoryuken::Manager do
       fetcher = double('Fetcher').as_null_object
       subject.fetcher = fetcher
 
-      subject.pause_queue!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      subject.queue_empty(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
 
       sleep 0.5
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
     end
   end
 

--- a/spec/shoryuken/middleware/server/auto_delete_spec.rb
+++ b/spec/shoryuken/middleware/server/auto_delete_spec.rb
@@ -55,8 +55,8 @@ describe Shoryuken::Middleware::Server::AutoDelete do
       expect(sqs_queue).to_not receive(:delete_messages)
 
       expect {
-        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise }
-      }.to raise_error
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' }
+      }.to raise_error('failed')
     end
   end
 end

--- a/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -25,7 +25,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
     it 'does not retry the job by default' do
       expect(sqs_msg).not_to receive(:change_visibility)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.to raise_error('failed')
     end
 
     it 'does not retry the job if :retry_intervals is empty' do
@@ -33,7 +33,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
 
       expect(sqs_msg).not_to receive(:change_visibility)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.to raise_error('failed')
     end
 
     it 'retries the job if :retry_intervals is non-empty' do
@@ -42,7 +42,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 300)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'retries the job with exponential backoff' do
@@ -52,7 +52,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 1800)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'uses the last retry interval when :receive_count exceeds the size of :retry_intervals' do
@@ -62,7 +62,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 1800)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'limits the visibility timeout to 12 hours from receipt of message' do
@@ -71,7 +71,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 43198)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
   end
 end

--- a/spec/shoryuken/middleware/server/timing_spec.rb
+++ b/spec/shoryuken/middleware/server/timing_spec.rb
@@ -54,8 +54,8 @@ describe Shoryuken::Middleware::Server::Timing do
       end
 
       expect {
-        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise }
-      }.to raise_error
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' }
+      }.to raise_error('failed')
     end
   end
 end

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'shoryuken/polling'
+
+describe Shoryuken::Polling do
+  let(:queue1) { "shoryuken" }
+  let(:queue2) { "uppercut" }
+  let(:queues) { Array.new }
+
+  describe Shoryuken::Polling::WeightedRoundRobin do
+    subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
+
+    it "decreases weight" do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject).to eq [queue1, queue2]
+
+      subject.pause(queue1)
+
+      expect(subject).to eq [queue2]
+    end
+
+    it "increases weight" do
+      # [shoryuken, 3]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject).to eq [queue1, queue2]
+      subject.pause(queue1)
+      expect(subject).to eq [queue2]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1, queue1]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1, queue1, queue1]
+    end
+
+    it "cycles" do
+      # [shoryuken, 1]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue2
+
+      popped = []
+
+      (queues.size * 3).times do
+        popped << subject.next_queue
+      end
+
+      expect(popped).to eq(queues * 3)
+    end
+  end
+end

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 require 'shoryuken/polling'
 
 describe Shoryuken::Polling do
-  let(:queue1) { "shoryuken" }
-  let(:queue2) { "uppercut" }
+  let(:queue1) { 'shoryuken' }
+  let(:queue2) { 'uppercut' }
   let(:queues) { Array.new }
 
   describe Shoryuken::Polling::WeightedRoundRobin do
     subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
 
-    it "decreases weight" do
+    it 'decreases weight' do
       # [shoryuken, 2]
       # [uppercut,  1]
       queues << queue1
@@ -23,7 +23,7 @@ describe Shoryuken::Polling do
       expect(subject).to eq [queue2]
     end
 
-    it "increases weight" do
+    it 'increases weight' do
       # [shoryuken, 3]
       # [uppercut,  1]
       queues << queue1
@@ -45,7 +45,7 @@ describe Shoryuken::Polling do
       expect(subject).to eq [queue2, queue1, queue1, queue1]
     end
 
-    it "cycles" do
+    it 'cycles' do
       # [shoryuken, 1]
       # [uppercut,  1]
       queues << queue1

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -294,8 +294,8 @@ describe Shoryuken::Processor do
     context 'when the worker fails' do
       it 'does not extend the message invisibility' do
         expect(sqs_msg).to receive(:visibility_timeout=).never
-        expect_any_instance_of(TestWorker).to receive(:perform).and_raise 'worker failed'
-        expect { subject.process(queue, sqs_msg) }.to raise_error
+        expect_any_instance_of(TestWorker).to receive(:perform).and_raise 'failed'
+        expect { subject.process(queue, sqs_msg) }.to raise_error('failed')
       end
     end
   end


### PR DESCRIPTION
In order to be able to customize the order and manner in which Shoryuken polls SQS queues, the previous hard-coded strategy was extracted into a separate class.

This meant that some of the method names were altered to be more generic (for example rebalance_queue_weight! became messages_received), otherwise this was a direct extraction.

---

I don't think this is 100% ready for merging, I'm not entirely happy with the names and so forth but I think it's solid enough to start having a discussion around.

My motivation was to be able to have more strict prioritization semantics than provided by the default implementation. I also wanted the option to do an extended poll on the highest priority queue if all queues are empty rather than either continually polling them all or sleeping to not poll anything.

This is my custom strategy that achieves that:

```ruby
class StrictPriorityPolling
  include Shoryuken::Util

  def initialize(queues)
    @active_queues = unparse_queues(queues)
    @prioritized_queues = @active_queues.sort_by { |queue, priority| -priority }.map(&:first)
    @highest_priority = @prioritized_queues.first
    @queues_since_messages = 0
  end

  def active_queues
    @active_queues
  end

  def next_queue
    options = {}

    queue = @prioritized_queues[@queues_since_messages % @prioritized_queues.length]

    if @highest_priority == queue && @queues_since_messages > 0
      options[:wait_time_seconds] = 2
    end

    @queues_since_messages += 1

    Shoryuken::Polling::QueueConfiguration.new(queue, options)
  end

  def messages_present(queue)
    @queues_since_messages = 0
  end

  def pause(queue)
    # No-op
  end

  def restart(queue)
    # No-op
  end
end

Shoryuken.configure_server do |config|
  config.options[:polling_strategy] = StrictPriorityPolling
end
```

From this, a strategy could be developed that may satisfy #92.
