### PR TITLE
Remove constantize within worker_name

### DIFF
--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -30,7 +30,7 @@ module Shoryuken
           && sqs_msg.message_attributes['shoryuken_class'] \
           && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s
 
-        "ActiveJob/#{body['job_class'].constantize}"
+        "ActiveJob/#{body['job_class']}"
       else
         worker_class.to_s
       end


### PR DESCRIPTION
Constantize is non-trivial and as the result is only used to generate a string it seems redundant.