### PR TITLE
Use block-style logging in all places

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -41,7 +41,7 @@ module Shoryuken
       @launcher = Shoryuken::Launcher.new
 
       if callback = Shoryuken.start_callback
-        logger.info { "Calling Shoryuken.on_start block" }
+        logger.info { 'Calling Shoryuken.on_start block' }
         callback.call
       end
 

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -41,7 +41,7 @@ module Shoryuken
       @launcher = Shoryuken::Launcher.new
 
       if callback = Shoryuken.start_callback
-        logger.info "Calling Shoryuken.on_start block"
+        logger.info { "Calling Shoryuken.on_start block" }
         callback.call
       end
 
@@ -158,7 +158,7 @@ module Shoryuken
 
       @parser.banner = 'shoryuken [options]'
       @parser.on_tail '-h', '--help', 'Show help' do
-        logger.info @parser
+        logger.info { @parser }
         exit 1
       end
       @parser.parse!(argv)
@@ -166,22 +166,22 @@ module Shoryuken
     end
 
     def handle_signal(sig)
-      logger.info "Got #{sig} signal"
+      logger.info { "Got #{sig} signal" }
 
       case sig
       when 'USR1'
-        logger.info 'Received USR1, will soft shutdown down'
+        logger.info { 'Received USR1, will soft shutdown down' }
 
         launcher.stop
 
         exit 0
       when 'TTIN'
         Thread.list.each do |thread|
-          logger.info "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}"
+          logger.info { "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}" }
           if thread.backtrace
-            logger.info thread.backtrace.join("\n")
+            logger.info { thread.backtrace.join("\n") }
           else
-            logger.info '<no backtrace available>'
+            logger.info { '<no backtrace available>' }
           end
         end
 
@@ -189,9 +189,9 @@ module Shoryuken
         busy   = launcher.manager.instance_variable_get(:@busy).size
         queues = launcher.manager.instance_variable_get(:@queues)
 
-        logger.info "Ready: #{ready}, Busy: #{busy}, Active Queues: #{unparse_queues(queues)}"
+        logger.info { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{unparse_queues(queues)}" }
       else
-        logger.info "Received #{sig}, will shutdown down"
+        logger.info { "Received #{sig}, will shutdown down" }
 
         raise Interrupt
       end

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -34,7 +34,7 @@ module Shoryuken
     def config_file_options
       if (path = options[:config_file])
         unless File.exist?(path)
-          Shoryuken.logger.warn "Config file #{path} does not exist"
+          Shoryuken.logger.warn { "Config file #{path} does not exist" }
           path = nil
         end
       end
@@ -68,7 +68,7 @@ module Shoryuken
       aws_options = aws_options.merge(credentials: credentials) if credentials.set?
 
       if (callback = Shoryuken.aws_initialization_callback)
-        Shoryuken.logger.info 'Calling Shoryuken.on_aws_initialization block'
+        Shoryuken.logger.info { 'Calling Shoryuken.on_aws_initialization block' }
         callback.call(aws_options)
       end
 
@@ -97,7 +97,7 @@ module Shoryuken
         require File.expand_path('config/environment.rb')
       end
 
-      Shoryuken.logger.info 'Rails environment loaded'
+      Shoryuken.logger.info { 'Rails environment loaded' }
     end
 
     def merge_cli_defined_queues
@@ -141,7 +141,7 @@ module Shoryuken
       Shoryuken.worker_registry.queues.each do |queue|
         Shoryuken.worker_registry.workers(queue).each do |worker_class|
           if worker_class.instance_method(:perform).arity == 1
-            Shoryuken.logger.warn "[DEPRECATION] #{worker_class.name}#perform(sqs_msg) is deprecated. Please use #{worker_class.name}#perform(sqs_msg, body)"
+            Shoryuken.logger.warn { "[DEPRECATION] #{worker_class.name}#perform(sqs_msg) is deprecated. Please use #{worker_class.name}#perform(sqs_msg, body)" }
 
             worker_class.class_eval do
               alias_method :deprecated_perform, :perform
@@ -160,13 +160,13 @@ module Shoryuken
     end
 
     def validate_queues
-      Shoryuken.logger.warn 'No queues supplied' if Shoryuken.queues.empty?
+      Shoryuken.logger.warn { 'No queues supplied' } if Shoryuken.queues.empty?
 
       Shoryuken.queues.uniq.each do |queue|
         begin
           Shoryuken::Client.queues queue
         rescue Aws::SQS::Errors::NonExistentQueue
-          Shoryuken.logger.warn "AWS Queue '#{queue}' does not exist"
+          Shoryuken.logger.warn { "AWS Queue '#{queue}' does not exist" }
         end
       end
     end
@@ -177,7 +177,7 @@ module Shoryuken
 
       unless defined?(::ActiveJob)
         (all_queues - queues_with_workers).each do |queue|
-          Shoryuken.logger.warn "No worker supplied for '#{queue}'"
+          Shoryuken.logger.warn { "No worker supplied for '#{queue}'" }
         end
       end
     end

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -25,14 +25,14 @@ module Shoryuken
       watchdog('Fetcher#fetch died') do
         started_at = Time.now
 
-        logger.debug "Looking for new messages in '#{queue}'"
+        logger.debug { "Looking for new messages in '#{queue}'" }
 
         begin
           batch = Shoryuken.worker_registry.batch_receive_messages?(queue)
           limit = batch ? FETCH_LIMIT : available_processors
 
           if (sqs_msgs = Array(receive_messages(queue, limit))).any?
-            logger.info "Found #{sqs_msgs.size} messages for '#{queue}'"
+            logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
 
             if batch
               @manager.async.assign(queue, patch_sqs_msgs!(sqs_msgs))
@@ -42,7 +42,7 @@ module Shoryuken
 
             @manager.async.rebalance_queue_weight!(queue)
           else
-            logger.debug "No message found for '#{queue}'"
+            logger.debug { "No message found for '#{queue}'" }
 
             @manager.async.pause_queue!(queue)
           end
@@ -51,8 +51,8 @@ module Shoryuken
 
           logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
         rescue => ex
-          logger.error "Error fetching message: #{ex}"
-          logger.error ex.backtrace.first
+          logger.error { "Error fetching message: #{ex}" }
+          logger.error { ex.backtrace.first }
 
           @manager.async.dispatch
         end

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -36,7 +36,7 @@ module Shoryuken
 
     def actor_died(actor, reason)
       return if @done
-      logger.warn 'Shoryuken died due to the following error, cannot recover, process exiting'
+      logger.warn { 'Shoryuken died due to the following error, cannot recover, process exiting' }
       exit 1
     end
   end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -23,7 +23,7 @@ module Shoryuken
     end
 
     def start
-      logger.info 'Starting'
+      logger.info { 'Starting' }
 
       dispatch
     end
@@ -33,7 +33,7 @@ module Shoryuken
         @done = true
 
         if (callback = Shoryuken.stop_callback)
-          logger.info 'Calling Shoryuken.on_stop block'
+          logger.info { 'Calling Shoryuken.on_stop block' }
           callback.call
         end
 
@@ -58,7 +58,7 @@ module Shoryuken
 
     def processor_done(queue, processor)
       watchdog('Manager#processor_done died') do
-        logger.debug "Process done for '#{queue}'"
+        logger.debug { "Process done for '#{queue}'" }
 
         @threads.delete(processor.object_id)
         @busy.delete processor
@@ -73,7 +73,7 @@ module Shoryuken
 
     def processor_died(processor, reason)
       watchdog("Manager#processor_died died") do
-        logger.error "Process died, reason: #{reason}" unless reason.to_s.empty?
+        logger.error { "Process died, reason: #{reason}" unless reason.to_s.empty? }
 
         @threads.delete(processor.object_id)
         @busy.delete processor
@@ -90,7 +90,7 @@ module Shoryuken
 
     def assign(queue, sqs_msg)
       watchdog('Manager#assign died') do
-        logger.debug "Assigning #{sqs_msg.message_id}"
+        logger.debug { "Assigning #{sqs_msg.message_id}" }
 
         processor = @ready.pop
         @busy << processor
@@ -102,7 +102,7 @@ module Shoryuken
     def rebalance_queue_weight!(queue)
       watchdog('Manager#rebalance_queue_weight! died') do
         if (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
-          logger.info "Increasing '#{queue}' weight to #{current + 1}, max: #{original}"
+          logger.info { "Increasing '#{queue}' weight to #{current + 1}, max: #{original}" }
 
           @queues << queue
         end
@@ -112,7 +112,7 @@ module Shoryuken
     def pause_queue!(queue)
       return if !@queues.include?(queue) || Shoryuken.options[:delay].to_f <= 0
 
-      logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty"
+      logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty" }
 
       @queues.delete(queue)
 
@@ -158,7 +158,7 @@ module Shoryuken
       return if stopped?
 
       unless @queues.include? queue
-        logger.debug "Restarting '#{queue}'"
+        logger.debug { "Restarting '#{queue}'" }
 
         @queues << queue
 
@@ -192,7 +192,7 @@ module Shoryuken
 
       unless defined?(::ActiveJob) ||  !Shoryuken.worker_registry.workers(queue).empty?
         # when no worker registered pause the queue to avoid endless recursion
-        logger.debug "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered"
+        logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered" }
 
         after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
 

--- a/lib/shoryuken/middleware/chain.rb
+++ b/lib/shoryuken/middleware/chain.rb
@@ -117,7 +117,7 @@ module Shoryuken
 
       def patch_deprecated_middleware!(klass)
         if klass.instance_method(:call).arity == 3
-          Shoryuken.logger.warn "[DEPRECATION] #{klass.name}#call(worker_instance, queue, sqs_msg) is deprecated. Please use #{klass.name}#call(worker_instance, queue, sqs_msg, body)"
+          Shoryuken.logger.warn { "[DEPRECATION] #{klass.name}#call(worker_instance, queue, sqs_msg) is deprecated. Please use #{klass.name}#call(worker_instance, queue, sqs_msg, body)" }
 
           klass.class_eval do
             alias_method :deprecated_call, :call

--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -42,7 +42,7 @@ module Shoryuken
 
           sqs_msg.change_visibility(visibility_timeout: interval.to_i)
 
-          logger.info "Message #{sqs_msg.message_id} failed, will be retried in #{interval} seconds."
+          logger.info { "Message #{sqs_msg.message_id} failed, will be retried in #{interval} seconds." }
         end
       end
     end

--- a/lib/shoryuken/middleware/server/timing.rb
+++ b/lib/shoryuken/middleware/server/timing.rb
@@ -9,19 +9,19 @@ module Shoryuken
             begin
               started_at = Time.now
 
-              logger.info "started at #{started_at}"
+              logger.info { "started at #{started_at}" }
 
               yield
 
               total_time = elapsed(started_at)
 
               if (total_time / 1000.0) > (timeout = Shoryuken::Client.queues(queue).visibility_timeout)
-                logger.warn "exceeded the queue visibility timeout by #{total_time - (timeout * 1000)} ms"
+                logger.warn { "exceeded the queue visibility timeout by #{total_time - (timeout * 1000)} ms" }
               end
 
-              logger.info "completed in: #{total_time} ms"
+              logger.info { "completed in: #{total_time} ms" }
             rescue => e
-              logger.info "failed in: #{elapsed(started_at)} ms"
+              logger.info { "failed in: #{elapsed(started_at)} ms" }
               raise e
             end
           end

--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -42,11 +42,11 @@ module Shoryuken
 
         every(queue_visibility_timeout - 5) do
           begin
-            logger.debug "Extending message #{worker_name(worker_class, sqs_msg)}/#{queue}/#{sqs_msg.message_id} visibility timeout by #{queue_visibility_timeout}s."
+            logger.debug { "Extending message #{worker_name(worker_class, sqs_msg)}/#{queue}/#{sqs_msg.message_id} visibility timeout by #{queue_visibility_timeout}s." }
 
             sqs_msg.visibility_timeout = queue_visibility_timeout
           rescue => e
-            logger.error "Could not auto extend the message #{worker_class}/#{queue}/#{sqs_msg.message_id} visibility timeout. Error: #{e.message}"
+            logger.error { "Could not auto extend the message #{worker_class}/#{queue}/#{sqs_msg.message_id} visibility timeout. Error: #{e.message}" }
           end
         end
       end
@@ -89,7 +89,7 @@ module Shoryuken
         end
       end
     rescue => e
-      logger.error "Error parsing the message body: #{e.message}\nbody_parser: #{body_parser}\nsqs_msg.body: #{sqs_msg.body}"
+      logger.error { "Error parsing the message body: #{e.message}\nbody_parser: #{body_parser}\nsqs_msg.body: #{sqs_msg.body}" }
       nil
     end
   end

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -3,9 +3,9 @@ module Shoryuken
     def watchdog(last_words)
       yield
     rescue => ex
-      logger.error last_words
-      logger.error ex
-      logger.error ex.backtrace.join("\n")
+      logger.error { last_words }
+      logger.error { ex }
+      logger.error { ex.backtrace.join("\n") }
     end
 
     def logger

--- a/spec/shoryuken/middleware/chain_spec.rb
+++ b/spec/shoryuken/middleware/chain_spec.rb
@@ -59,7 +59,7 @@ describe Shoryuken::Middleware::Chain do
     subject.clear
 
     expect(Shoryuken.logger).to receive(:warn) do |&block|
-      expect(block.call).to eq("[DEPRECATION] DeprecatedMiddleware#call(worker_instance, queue, sqs_msg) is deprecated. Please use DeprecatedMiddleware#call(worker_instance, queue, sqs_msg, body)")
+      expect(block.call).to eq('[DEPRECATION] DeprecatedMiddleware#call(worker_instance, queue, sqs_msg) is deprecated. Please use DeprecatedMiddleware#call(worker_instance, queue, sqs_msg, body)')
     end
 
     subject.add DeprecatedMiddleware

--- a/spec/shoryuken/middleware/chain_spec.rb
+++ b/spec/shoryuken/middleware/chain_spec.rb
@@ -58,7 +58,9 @@ describe Shoryuken::Middleware::Chain do
   it 'patches deprecated middleware' do
     subject.clear
 
-    expect(Shoryuken.logger).to receive(:warn).with("[DEPRECATION] DeprecatedMiddleware#call(worker_instance, queue, sqs_msg) is deprecated. Please use DeprecatedMiddleware#call(worker_instance, queue, sqs_msg, body)")
+    expect(Shoryuken.logger).to receive(:warn) do |&block|
+      expect(block.call).to eq("[DEPRECATION] DeprecatedMiddleware#call(worker_instance, queue, sqs_msg) is deprecated. Please use DeprecatedMiddleware#call(worker_instance, queue, sqs_msg, body)")
+    end
 
     subject.add DeprecatedMiddleware
 

--- a/spec/shoryuken/middleware/server/timing_spec.rb
+++ b/spec/shoryuken/middleware/server/timing_spec.rb
@@ -16,8 +16,12 @@ describe Shoryuken::Middleware::Server::Timing do
   end
 
   it 'logs timing' do
-    expect(Shoryuken.logger).to receive(:info).with(/started at/)
-    expect(Shoryuken.logger).to receive(:info).with(/completed in/)
+    expect(Shoryuken.logger).to receive(:info) do |&block|
+      expect(block.call).to match(/started at/)
+    end
+    expect(Shoryuken.logger).to receive(:info) do |&block|
+      expect(block.call).to match(/completed in/)
+    end
 
     subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) {}
   end
@@ -26,9 +30,15 @@ describe Shoryuken::Middleware::Server::Timing do
     it 'logs exceeded' do
       allow(subject).to receive(:elapsed).and_return(120000)
 
-      expect(Shoryuken.logger).to receive(:info).with(/started at/)
-      expect(Shoryuken.logger).to receive(:info).with(/completed in/)
-      expect(Shoryuken.logger).to receive(:warn).with('exceeded the queue visibility timeout by 60000 ms')
+      expect(Shoryuken.logger).to receive(:info) do |&block|
+        expect(block.call).to match(/started at/)
+      end
+      expect(Shoryuken.logger).to receive(:info) do |&block|
+        expect(block.call).to match(/completed in/)
+      end
+      expect(Shoryuken.logger).to receive(:warn) do |&block|
+        expect(block.call).to match('exceeded the queue visibility timeout by 60000 ms')
+      end
 
       subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) {}
     end
@@ -36,8 +46,12 @@ describe Shoryuken::Middleware::Server::Timing do
 
   context 'when exception' do
     it 'logs failed in' do
-      expect(Shoryuken.logger).to receive(:info).with(/started at/)
-      expect(Shoryuken.logger).to receive(:info).with(/failed in/)
+      expect(Shoryuken.logger).to receive(:info) do |&block|
+        expect(block.call).to match(/started at/)
+      end
+      expect(Shoryuken.logger).to receive(:info) do |&block|
+        expect(block.call).to match(/failed in/)
+      end
 
       expect {
         subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise }

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -99,7 +99,9 @@ describe Shoryuken::Processor do
 
         allow(sqs_msg).to receive(:body).and_return('invalid json')
 
-        expect(subject.logger).to receive(:error).with("Error parsing the message body: 757: unexpected token at 'invalid json'\nbody_parser: json\nsqs_msg.body: invalid json")
+        expect(subject.logger).to receive(:error) do |&block|
+          expect(block.call).to eq("Error parsing the message body: 757: unexpected token at 'invalid json'\nbody_parser: json\nsqs_msg.body: invalid json")
+        end
 
         subject.process(queue, sqs_msg)
       end


### PR DESCRIPTION
Non-block style logging seems to be, at least partially, responsible for a form of memory leak depending on your configuration.

See https://github.com/phstc/shoryuken/issues/88#issuecomment-113598856 for details of how I came to decide to make this change. I know it doesn't really make sense but I've explained how to reproduce my results. Let me know if you need any more details.

Here's a chart of memory usage on one of our production servers showing a before and after:

![screen_shot_2015-06-20_at_06_57_56](https://cloud.githubusercontent.com/assets/81344/8266256/8e6b34d6-171b-11e5-9a3a-973b065a8c13.png)

This might be the first of a few PRs as I don't think the problem is solved. My gut feel is that the baseline memory usage should still be higher than it is.