### PR TITLE
Pass the queue into the message object on initialize.

### DIFF
--- a/lib/shoryuken/message.rb
+++ b/lib/shoryuken/message.rb
@@ -1,11 +1,21 @@
 module Shoryuken
   class Message
-    attr_accessor :client, :queue_url, :data
+    attr_accessor :client, :queue_url, :queue_name, :data
 
-    def initialize(client, queue_url, data)
+    def initialize(client, queue, data)
       self.client = client
-      self.queue_url = queue_url
       self.data = data
+
+      if queue.is_a?(Shoryuken::Queue)
+        self.queue_url = queue.url
+        self.queue_name = queue.name
+      else
+        # TODO: Remove next major release
+        Shoryuken.loggger.warn do
+          '[DEPRECATION] Passing a queue url into Shoryuken::Message is deprecated, please pass the queue itself'
+        end
+        self.queue_url = queue
+      end
     end
 
     def delete

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -34,7 +34,7 @@ module Shoryuken
     def receive_messages(options)
       client.receive_message(options.merge(queue_url: url)).
         messages.
-        map { |m| Message.new(client, url, m) }
+        map { |m| Message.new(client, self, m) }
     end
 
     private


### PR DESCRIPTION
Instead of just passing in the queue url, pass in the queue instead. We
can take what information we need, or delegate certain behavior if we
choose to store the queue which would require no further interface
changes.