### PR TITLE
Allow configuration of SQS/SNS endpoints via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The ```aws``` section is used to configure both the Aws objects used by Shoryuke
 - ```sqs_endpoint``` can be used to explicitly override the SQS endpoint
 - ```receive_message``` can be used to define the options passed to the http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#receive_message-instance_method
 
+The ```sns_endpoint``` and ```sqs_endpoint``` Shoryuken-specific options will also fallback to the environment variables ```AWS_SNS_ENDPOINT``` and ```AWS_SQS_ENDPOINT``` respectively, if they are set.
+
 ### Rails Integration
 
 [Check the Rails Integration Active Job documention](https://github.com/phstc/shoryuken/wiki/Rails-Integration-Active-Job).

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -30,7 +30,8 @@ module Shoryuken
       private
 
       def aws_client_options(service_endpoint_key)
-        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key]
+        environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
+        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key] || environment_endpoint
         options = {}
         options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
         options

--- a/spec/shoryuken/client_spec.rb
+++ b/spec/shoryuken/client_spec.rb
@@ -5,17 +5,58 @@ describe Shoryuken::Client do
   let(:sqs)         { Aws::SQS::Client.new(stub_responses: true, credentials: credentials) }
   let(:queue_name)  { 'shoryuken' }
   let(:queue_url)   { 'https://eu-west-1.amazonaws.com:6059/123456789012/shoryuken' }
-
-  before do
-    described_class.sqs = sqs
-  end
+  let(:sqs_endpoint) { 'http://localhost:4568' }
+  let(:sns_endpoint) { 'http://0.0.0.0:4568'   }
 
   describe '.queue' do
+    before do
+      described_class.sqs = sqs
+    end
     it 'memoizes queues' do
       sqs.stub_responses(:get_queue_url, { queue_url: queue_url }, { queue_url: 'xyz' })
 
       expect(Shoryuken::Client.queues(queue_name).url).to eq queue_url
       expect(Shoryuken::Client.queues(queue_name).url).to eq queue_url
     end
+  end
+
+  describe 'environment variable endpoints' do
+    before do
+      ENV['AWS_SQS_ENDPOINT'] = sqs_endpoint
+      ENV['AWS_SNS_ENDPOINT'] = sns_endpoint
+      ENV['AWS_REGION'] = 'us-east-1'
+      Shoryuken.options[:aws] = {}
+    end
+
+    it 'will use config file settings if set' do
+      load_config_file_by_file_name('shoryuken_endpoint.yml')
+      expect(described_class.sqs.config.endpoint.to_s).to eql('https://github.com/phstc/shoryuken:4568')
+      expect(described_class.sns.config.endpoint.to_s).to eq('http://127.0.0.1:4568')
+    end
+
+    it 'should fallback to environment variable if config file not found or set' do
+      load_config_file_by_file_name(nil)
+      expect(described_class.sqs.config.endpoint.to_s).to eql(sqs_endpoint)
+      expect(described_class.sns.config.endpoint.to_s).to eq(sns_endpoint)
+    end
+
+    it 'should fallback to environment variable if config file found but settings not set' do
+      load_config_file_by_file_name('shoryuken.yml')
+      expect(described_class.sqs.config.endpoint.to_s).to eql(sqs_endpoint)
+      expect(described_class.sns.config.endpoint.to_s).to eq(sns_endpoint)
+    end
+
+    it 'will fallback to default settings if no config file settings or environment variables found' do
+      ENV['AWS_SQS_ENDPOINT'] = nil
+      ENV['AWS_SNS_ENDPOINT'] = nil
+      load_config_file_by_file_name('shoryuken.yml')
+      expect(described_class.sqs.config.endpoint.to_s).to eql('https://sqs.us-east-1.amazonaws.com')
+      expect(described_class.sns.config.endpoint.to_s).to eq('https://sns.us-east-1.amazonaws.com')
+    end
+  end
+
+  def load_config_file_by_file_name(file_name)
+    path_name = file_name ? File.join(File.expand_path('../../..', __FILE__), 'spec', file_name) : nil
+    Shoryuken::EnvironmentLoader.load(config_file: path_name)
   end
 end

--- a/spec/shoryuken_endpoint.yml
+++ b/spec/shoryuken_endpoint.yml
@@ -1,0 +1,6 @@
+aws:
+  access_key_id:      <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region:             us-east-1
+  sqs_endpoint: https://github.com/phstc/shoryuken:4568
+  sns_endpoint: http://127.0.0.1:4568


### PR DESCRIPTION
As a response to #128, allow SQS/SNS endpoints to be configured via environment variables, such as in use for local integration testing (e.g. [fake_sqs](https://github.com/iain/fake_sqs) ).

As far as I can see for now, this would allow full configuration on the publisher side using environment variables without requiring the Shoryuken configuration file.