### PR TITLE
Re raise body parser exceptions.

### DIFF
--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -90,7 +90,7 @@ module Shoryuken
       end
     rescue => e
       logger.error { "Error parsing the message body: #{e.message}\nbody_parser: #{body_parser}\nsqs_msg.body: #{sqs_msg.body}" }
-      nil
+      raise
     end
   end
 end

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -92,18 +92,22 @@ describe Shoryuken::Processor do
     end
 
     context 'when parse errors' do
-      it 'does not fail' do
+      before do
         TestWorker.get_shoryuken_options['body_parser'] = :json
 
-        expect_any_instance_of(TestWorker).to receive(:perform).with(sqs_msg, nil)
-
         allow(sqs_msg).to receive(:body).and_return('invalid json')
+      end
 
+      it 'logs the error' do
         expect(subject.logger).to receive(:error) do |&block|
           expect(block.call).to eq("Error parsing the message body: 757: unexpected token at 'invalid json'\nbody_parser: json\nsqs_msg.body: invalid json")
         end
 
-        subject.process(queue, sqs_msg)
+        subject.process(queue, sqs_msg) rescue nil
+      end
+
+      it 're raises the error' do
+        expect{subject.process(queue, sqs_msg)}.to raise_error(JSON::ParserError, "757: unexpected token at 'invalid json'")
       end
     end
 


### PR DESCRIPTION
Fixes #135.

When a error occurs when parsing the body, crash the worker. This falls in line with celluloids "let it fail" mentality, and also prevents middleware like auto delete from progressing normally when the body couldn't be parsed.

cc @phstc (could we make another rubygems release after this one?)