### PR TITLE
Fix Active Job queue prefixing in Rails apps

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -113,7 +113,7 @@ module Shoryuken
     end
 
     def prefix_active_job_queue_names
-      return unless @options[:rails]
+      return unless @options[:rails] || defined? Rails
       return unless Shoryuken.active_job_queue_name_prefixing
 
       queue_name_prefix = ::ActiveJob::Base.queue_name_prefix

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -113,7 +113,7 @@ module Shoryuken
     end
 
     def prefix_active_job_queue_names
-      return unless @options[:rails] || defined? Rails
+      return unless defined? ::ActiveJob
       return unless Shoryuken.active_job_queue_name_prefixing
 
       queue_name_prefix = ::ActiveJob::Base.queue_name_prefix


### PR DESCRIPTION
There was an issue where Active Job prefixes were not being applied if the Shoryuken environment was being loaded outside of the CLI with the `--rails` flag (i.e. in a Rails app itself). This change allows the prefixing to occur as long as `Rails` is defined.