### PR TITLE
Allow passing array of messages to send_messages

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -43,7 +43,7 @@ module Shoryuken
       options = case
                 when options.is_a?(Array)
                   { entries: options.map.with_index do |m, index|
-                    { id: index.to_s }.merge(m.is_a?(Hash) ? m : { message_body: m } )
+                    { id: index.to_s }.merge(m.is_a?(Hash) ? m : { message_body: m })
                   end }
                 when options.is_a?(Hash)
                   options

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -42,7 +42,9 @@ module Shoryuken
     def sanitize_messages!(options)
       options = case
                 when options.is_a?(Array)
-                  { entries: options.map.with_index { |m, index| { id: index.to_s, message_body: m } } }
+                  { entries: options.map.with_index do |m, index|
+                    { id: index.to_s }.merge(m.is_a?(Hash) ? m : { message_body: m } )
+                  end }
                 when options.is_a?(Hash)
                   options
                 end

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -82,11 +82,11 @@ describe Shoryuken::Queue do
 
       subject.send_messages([
         {
-          message_body: "msg1",
+          message_body: 'msg1',
           delay_seconds: 1,
           message_attributes: { attr: 'attr1' }
         }, {
-          message_body: "msg2",
+          message_body: 'msg2',
           delay_seconds: 1,
           message_attributes: { attr: 'attr2' }
         }

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -77,6 +77,22 @@ describe Shoryuken::Queue do
       subject.send_messages(entries: [{ id: '0', message_body: 'msg1'}, { id: '1', message_body: 'msg2' }])
     end
 
+    it 'accepts an array of messages' do
+      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1', delay_seconds: 1, message_attributes: { attr: 'attr1' } }, { id: '1', message_body: 'msg2', delay_seconds: 1, message_attributes: { attr: 'attr2' } }]))
+
+      subject.send_messages([
+        {
+          message_body: "msg1",
+          delay_seconds: 1,
+          message_attributes: { attr: 'attr1' }
+        }, {
+          message_body: "msg2",
+          delay_seconds: 1,
+          message_attributes: { attr: 'attr2' }
+        }
+      ])
+    end
+
     it 'accepts an array of string' do
       expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1'}, { id: '1', message_body: 'msg2' }]))
 


### PR DESCRIPTION
I can't come up with a good reason why this would be the intended behavior, so I think it's a bug.

If a set of messages is passed to a queue like `queue.send_messages(batch)`, where `batch` is:

```
[
    {
        message_body: "foo",
        delay_seconds: 1,
        message_attributes: {...}
    }, {
        message_body: "foo",
        delay_seconds: 1,
        message_attributes: {...}
    }
]
```

the messages are being corrupted before they actually get sent by `send_message_batch` on the client.

When [`sanitize_messages!`](https://github.com/phstc/shoryuken/blob/master/lib/shoryuken/queue.rb#L45) tries to reformat the value from an `Array` to a `Hash` that is properly wrapped and ID'd, it doesn't take into account that the members of the array may be hashes. When hashes like in the example are used, the entire hash ends up getting serialized and shoved into `message_body`.

This change properly maintains the messages and adds an index, or behaves the old way if a string body is all that's getting passed in.