### PR TITLE
Fix warnings triggered by raise_error matcher

### DIFF
--- a/spec/shoryuken/middleware/server/auto_delete_spec.rb
+++ b/spec/shoryuken/middleware/server/auto_delete_spec.rb
@@ -55,8 +55,8 @@ describe Shoryuken::Middleware::Server::AutoDelete do
       expect(sqs_queue).to_not receive(:delete_messages)
 
       expect {
-        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise }
-      }.to raise_error
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'Error' }
+      }.to raise_error(RuntimeError, 'Error')
     end
   end
 end

--- a/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -25,7 +25,9 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
     it 'does not retry the job by default' do
       expect(sqs_msg).not_to receive(:change_visibility)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.to raise_error
+      expect {
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'Error' }
+      }.to raise_error(RuntimeError, 'Error')
     end
 
     it 'does not retry the job if :retry_intervals is empty' do
@@ -33,7 +35,9 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
 
       expect(sqs_msg).not_to receive(:change_visibility)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.to raise_error
+      expect {
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'Error' }
+      }.to raise_error(RuntimeError, 'Error')
     end
 
     it 'retries the job if :retry_intervals is non-empty' do

--- a/spec/shoryuken/middleware/server/timing_spec.rb
+++ b/spec/shoryuken/middleware/server/timing_spec.rb
@@ -54,8 +54,8 @@ describe Shoryuken::Middleware::Server::Timing do
       end
 
       expect {
-        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise }
-      }.to raise_error
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'Error' }
+      }.to raise_error(RuntimeError, 'Error')
     end
   end
 end

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -299,7 +299,7 @@ describe Shoryuken::Processor do
       it 'does not extend the message invisibility' do
         expect(sqs_msg).to receive(:visibility_timeout=).never
         expect_any_instance_of(TestWorker).to receive(:perform).and_raise 'worker failed'
-        expect { subject.process(queue, sqs_msg) }.to raise_error
+        expect { subject.process(queue, sqs_msg) }.to raise_error(RuntimeError, 'worker failed')
       end
     end
   end


### PR DESCRIPTION
Fix warnings that are triggered when the `raise_error` matcher
is used without providing a specific error class or message.

The warning quoted:
>WARNING: Using the `raise_error` matcher without providing a specific error or
>message risks false positives, since `raise_error` will match when Ruby raises
>a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the
>expectation to pass without even executing the method you are intending to
>call. Instead consider providing a specific error class or message. This
>message can be supressed by setting:
>`RSpec::Expectations.configuration.warn_about_potential_false_positives =
>false`.