### PR TITLE
Setup Vagrant machine for easier provisioning of a dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,38 @@ Please check the [Shoryuken Wiki](https://github.com/phstc/shoryuken/wiki).
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+### Setup Development Environment
+
+A provisioned vagrant box allows for a fast setup of a fresh development environment
+which comes with all development dependencies installed.
+Install [Vagrant](https://www.vagrantup.com/) (if you haven't already). We also
+suggest that you make yourself familiar with the general concepts. The documentation section includes
+a nice and comprehensive [Getting started](https://docs.vagrantup.com/v2/getting-started/) guide.
+
+Start up the vitual machine and log into it:
+```bash
+$ vagrant up
+$ vagrant ssh
+
+Welcome to Ubuntu 14.04.2 LTS (GNU/Linux 3.13.0-52-generic x86_64)..
+.
+.
+vagrant@shoryuken-dev-box:~$
+```
+Change to the working directory which is mounted at `/vagrant`:
+```bash
+vagrant@shoryuken-dev-box:~$: cd /vagrant
+vagrant@shoryuken-dev-box:~$: ls
+
+bin           CHANGELOG.md  Gemfile       lib          Rakefile   shoryuken.gemspec  spec
+bootstrap.sh  examples      Gemfile.lock  LICENSE.txt  README.md  shoryuken.jpg      Vagrantfile
+```
+
+These are the actual files and directories of the repository which are shared
+with the virtual machine. You can still edit the files directly on your host system
+with your editor or IDE of choice. Afterwards, run the tests
+inside the vagrant virtual machine:
+```bash
+vagrant@shoryuken-dev-box:/vagrant$ bundle install && SPEC_ALL=true bundle exec rspec spec
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,18 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.hostname = 'shoryuken-dev-box'
+  config.vm.provision :shell, path: 'bootstrap.sh', keep_color: true
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,57 @@
+# The boostrap script is partly taken from the rails-dev-box project.
+# The original source file can be found here
+# https://github.com/rails/rails-dev-box/blob/2fcf12eee6ce2469d9988694dcaf07ab5c2c3524/bootstrap.sh 
+#
+# As expressed by the copyright holder, the following copyright notice is
+# included.
+
+# Copyright (c) 2012-ω Xavier Noria
+# 
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# 
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+# The output of all these installation steps is noisy. With this utility
+# the progress report is nice and concise.
+function install {
+    echo installing $1
+    shift
+    apt-get -y install "$@" >/dev/null 2>&1
+}
+
+echo updating package information
+apt-add-repository -y ppa:brightbox/ruby-ng >/dev/null 2>&1
+apt-get -y update >/dev/null 2>&1
+
+install 'development tools' build-essential
+
+install Ruby ruby2.2 ruby2.2-dev
+update-alternatives --set ruby /usr/bin/ruby2.2 >/dev/null 2>&1
+update-alternatives --set gem /usr/bin/gem2.2 >/dev/null 2>&1
+
+echo installing Bundler
+gem install bundler -N >/dev/null 2>&1
+
+install Git git
+
+# Dependency to install the nokogiri gem
+install zlib1g-dev zlib1g-dev
+
+update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8


### PR DESCRIPTION
Add a Vagrantfile that provisions a virtual machine with
all dependencies installed to run the rspec test suite.
Dependencies include for example ruby2.2, zlib1g-dev, etc..

To fire up the virtual machine, install
[Vagrant](https://www.vagrantup.com/) and run:
```bash
vagrant up
vagrant ssh
```