### PR TITLE
Enable override the default queue with a :queue option

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -6,7 +6,6 @@ module Shoryuken
 
     module ClassMethods
       def perform_async(body, options = {})
-        options ||= {}
         options[:message_attributes] ||= {}
         options[:message_attributes]['shoryuken_class'] = {
           string_value: self.to_s,

--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -14,7 +14,9 @@ module Shoryuken
 
         options[:message_body] = body
 
-        Shoryuken::Client.queues(get_shoryuken_options['queue']).send_message(options)
+        queue = options.delete(:queue) || get_shoryuken_options['queue']
+
+        Shoryuken::Client.queues(queue).send_message(options)
       end
 
       def perform_in(interval, body, options = {})

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -79,6 +79,23 @@ describe 'Shoryuken::Worker' do
 
       TestWorker.perform_async('delayed message', delay_seconds: 60)
     end
+
+    it 'accepts an `queue` option' do
+      new_queue = 'some_different_queue'
+
+      expect(Shoryuken::Client).to receive(:queues).with(new_queue).and_return(sqs_queue)
+
+      expect(sqs_queue).to receive(:send_message).with(
+        message_attributes: {
+          'shoryuken_class' => {
+            string_value: TestWorker.to_s,
+            data_type: 'String'
+          }
+        },
+        message_body: 'delayed message')
+
+      TestWorker.perform_async('delayed message', queue: new_queue)
+    end
   end
 
   describe '.shoryuken_options' do


### PR DESCRIPTION
While working on a data migation I came across the need to dynamically configure the queue that a job would go to (i.e. `high_priority` vs `low_priority` or queueing data from a system singleton into production into staging).

This PR allows a client to configure which queue to send to at the time of queuing the job

```
MyWorker.perform_async('Pablo', queue: 'new_queue')
```