### PR TITLE
Fix undefined method error at EnvironmentLoader

### DIFF
--- a/lib/shoryuken/core_ext.rb
+++ b/lib/shoryuken/core_ext.rb
@@ -1,35 +1,47 @@
+module Shoryuken
+  module CoreExt
+    module StringifyKeys
+      def stringify_keys
+        keys.each do |key|
+          self[key.to_s] = delete(key)
+        end
+        self
+      end
+    end
+
+    module SymbolizeKeys
+      def symbolize_keys
+        keys.each do |key|
+          self[(key.to_sym rescue key) || key] = delete(key)
+        end
+        self
+      end
+    end
+
+    module DeepSymbolizeKeys
+      def deep_symbolize_keys
+        keys.each do |key|
+          value = delete(key)
+          self[(key.to_sym rescue key) || key] = value
+
+          value.deep_symbolize_keys if value.is_a? Hash
+        end
+        self
+      end
+    end
+  end
+end
+
 begin
   require 'active_support/core_ext/hash/keys'
   require 'active_support/core_ext/hash/deep_merge'
-  {}.stringify_keys
-  {}.symbolize_keys
-  {}.deep_symbolize_keys
-rescue LoadError, NoMethodError
-  class Hash
-    def stringify_keys
-      keys.each do |key|
-        self[key.to_s] = delete(key)
-      end
-      self
-    end if !{}.respond_to?(:stringify_keys)
+rescue LoadError
+end
 
-    def symbolize_keys
-      keys.each do |key|
-        self[(key.to_sym rescue key) || key] = delete(key)
-      end
-      self
-    end if !{}.respond_to?(:symbolize_keys)
-
-    def deep_symbolize_keys
-      keys.each do |key|
-        value = delete(key)
-        self[(key.to_sym rescue key) || key] = value
-
-        value.deep_symbolize_keys if value.is_a? Hash
-      end
-      self
-    end if !{}.respond_to?(:deep_symbolize_keys)
-  end
+class Hash
+  include Shoryuken::CoreExt::StringifyKeys unless method_defined?(:stringify_keys)
+  include Shoryuken::CoreExt::SymbolizeKeys unless method_defined?(:symbolize_keys)
+  include Shoryuken::CoreExt::DeepSymbolizeKeys unless method_defined?(:deep_symbolize_keys)
 end
 
 begin

--- a/lib/shoryuken/core_ext.rb
+++ b/lib/shoryuken/core_ext.rb
@@ -1,7 +1,10 @@
 begin
   require 'active_support/core_ext/hash/keys'
   require 'active_support/core_ext/hash/deep_merge'
-rescue LoadError
+  {}.stringify_keys
+  {}.symbolize_keys
+  {}.deep_symbolize_keys
+rescue LoadError, NoMethodError
   class Hash
     def stringify_keys
       keys.each do |key|


### PR DESCRIPTION
When I use `Shoryuken::EnvironmentLoader#load` in Rails3, I got an raised error below.
```
/vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/shoryuken-2.0.3/lib/shoryuken/environment_loader.rb:44:in `config_file_options': undefined method `deep_symbolize_keys' for #<Hash:0x007f657fb98048> (NoMethodError)
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/shoryuken-2.0.3/lib/shoryuken/environment_loader.rb:20:in `load'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/shoryuken-2.0.3/lib/shoryuken/environment_loader.rb:6:in `load'
	from /vagrant/crowdworks/config/initializers/shoryuken.rb:17:in `<top (required)>'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:245:in `load'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:245:in `block in load'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:245:in `load'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/engine.rb:593:in `block (2 levels) in <class:Engine>'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/engine.rb:592:in `each'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/engine.rb:592:in `block in <class:Engine>'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/initializable.rb:30:in `instance_exec'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/initializable.rb:30:in `run'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/initializable.rb:54:in `each'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/initializable.rb:54:in `run_initializers'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/application.rb:136:in `initialize!'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/railtie/configurable.rb:30:in `method_missing'
	from /vagrant/crowdworks/config/environment.rb:5:in `<top (required)>'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:251:in `require'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:251:in `block in require'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:236:in `load_dependency'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/activesupport-3.2.22/lib/active_support/dependencies.rb:251:in `require'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/application.rb:103:in `require_environment!'
	from /vagrant/crowdworks/vendor/bundle/ruby/2.1.0/gems/railties-3.2.22/lib/rails/commands.rb:40:in `<top (required)>'
	from script/rails:6:in `require'
	from script/rails:6:in `<main>'
```
This is because ActiveSupport v3.2 does not define `Hash#deep_symbolize_keys`.
So, I've added  closely check hash methods in `core_ext.rb`.