### PR TITLE
update bundler before travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,5 @@ notifications:
     on_failure: always
 
 script: SPEC_ALL=true bundle exec rspec spec
+before_install:
+ - gem update bundler


### PR DESCRIPTION
Latest builds on travis are broken because bundler is too old and contains some issues.
Refs: bundler/bundler#3558 travis-ci/travis-ci#3531