### PR TITLE
Allow symbol as a queue name in shoryuken_options

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -68,6 +68,13 @@ module Shoryuken
           @shoryuken_options['queue'] = queue
         end
 
+        case @shoryuken_options['queue']
+        when Array
+          @shoryuken_options['queue'].map!(&:to_s)
+        when Symbol
+          @shoryuken_options['queue'] = @shoryuken_options['queue'].to_s
+        end
+
         [@shoryuken_options['queue']].flatten.compact.each(&method(:register_worker))
       end
 

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -142,6 +142,28 @@ RSpec.describe 'Shoryuken::Worker' do
       expect(GlobalDefaultsTestWorker.get_shoryuken_options['auto_delete']).to eq true
       expect(GlobalDefaultsTestWorker.get_shoryuken_options['batch']).to eq false
     end
+
+    it 'accepts a symbol as a queue and converts to string' do
+      class SymbolQueueTestWorker
+        include Shoryuken::Worker
+
+        shoryuken_options queue: :default
+      end
+
+      expect(SymbolQueueTestWorker.get_shoryuken_options['queue']).to eq 'default'
+    end
+
+    it 'accepts an array that contains symbols as a queue and converts to string' do
+      class WorkerMultipleSymbolQueues
+        include Shoryuken::Worker
+
+        shoryuken_options queue: %i[symbol_queue1 symbol_queue2 symbol_queue3]
+      end
+
+      expect(Shoryuken.worker_registry.workers('symbol_queue1')).to eq([WorkerMultipleSymbolQueues])
+      expect(Shoryuken.worker_registry.workers('symbol_queue2')).to eq([WorkerMultipleSymbolQueues])
+      expect(Shoryuken.worker_registry.workers('symbol_queue3')).to eq([WorkerMultipleSymbolQueues])
+    end
   end
 
   describe '.server_middleware' do


### PR DESCRIPTION
# What does this PullRequest change?

This PullRequest allows to use symbol for queue name in shoryuken_options.

e.g.

```ruby
class SymbolQueueTestWorker
  include Shoryuken::Worker

  shoryuken_options queue: :default
end
```

In this case, `:default` will be converted to `'default'`, and work.

# Why is this need?

To use Amazon SQS, I was about to convert a sidekiq worker class to a shoryuken worker class.
But my worker was not be handled by shoryuken worker process though I enqueued to SQS with valid format message...

The converted shoryuken worker class is like the following:

```ruby
class WhatOneceWasSidekiqWorker
  include Shoryuken::Worker

  shoryuken_options queue: :myworker
end
```

And I noticed that sidekiq worker accepts symbol queue name, but shoryuken does not.

But as far as I read shoryuken's codes , I could not find any special reasons that Shoryken has to force the queue name to be Symbol.

So if there are not any special reasons, I think it is better to allow the Symbol for portability from Sidekiq.
