### PR TITLE
Check that concurrency is set to a positive number. 

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -12,6 +12,7 @@ module Shoryuken
 
     def initialize(condvar)
       @count  = Shoryuken.options[:concurrency] || 25
+      raise(ArgumentError, "concurrency value #{@count} is invalid, the value needs to be a positive number") unless @count > 0
       @queues = Shoryuken.queues.dup.uniq
       @finished = condvar
 

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -11,8 +11,8 @@ module Shoryuken
     trap_exit :processor_died
 
     def initialize(condvar)
-      @count  = Shoryuken.options[:concurrency] || 25
-      raise(ArgumentError, "concurrency value #{@count} is invalid, the value needs to be a positive number") unless @count > 0
+      @count = Shoryuken.options[:concurrency] || 25
+      raise(ArgumentError, "concurrency value #{@count} is invalid, it needs to be a positive number") unless @count > 0
       @queues = Shoryuken.queues.dup.uniq
       @finished = condvar
 

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -8,6 +8,15 @@ describe Shoryuken::Manager do
     Shoryuken::Manager.new(condvar)
   end
 
+  describe 'Invalid concurrency setting' do
+    it 'raises ArgumentError if concurrency is not positive number' do
+      Shoryuken.options[:concurrency] = -1
+      expect{Shoryuken::Manager.new(nil)}
+      .to raise_error(ArgumentError, 'concurrency value -1 is invalid, the value needs to be a positive number')
+    end
+
+  end
+
   describe 'Auto Scaling' do
     it 'decreases weight' do
       queue1 = 'shoryuken'

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -11,8 +11,8 @@ describe Shoryuken::Manager do
   describe 'Invalid concurrency setting' do
     it 'raises ArgumentError if concurrency is not positive number' do
       Shoryuken.options[:concurrency] = -1
-      expect{Shoryuken::Manager.new(nil)}
-      .to raise_error(ArgumentError, 'concurrency value -1 is invalid, the value needs to be a positive number')
+      expect { Shoryuken::Manager.new(nil) }
+        .to raise_error(ArgumentError, 'concurrency value -1 is invalid, it needs to be a positive number')
     end
 
   end


### PR DESCRIPTION
Without this check, setting concurrency to -1 or to 0; will actually start the manager, but manager will not spawn any workers.


I've made the check at this level, alternatively perhaps cli.rb should fail as well if number passed is negative.
What I prefer with current approach is that argument verification is next to the code actually using the argument.

`@ready = @count.times.map { build_processor }` this is a `NOP` command if `@count` is negative or zero.