### PR TITLE
Fix initialize_logger to read logfile options from config file in EnvironmentLoader

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -18,6 +18,7 @@ module Shoryuken
       initialize_logger
       load_rails if options[:rails]
       Shoryuken.options.merge!(config_file_options)
+      reset_logger
       merge_cli_defined_queues
       prefix_active_job_queue_names
       Shoryuken.options.merge!(options)
@@ -78,6 +79,11 @@ module Shoryuken
     def initialize_logger
       Shoryuken::Logging.initialize_logger(options[:logfile]) if options[:logfile]
       Shoryuken.logger.level = Logger::DEBUG if options[:verbose]
+    end
+
+    def reset_logger
+      Shoryuken::Logging.initialize_logger(Shoryuken.options[:logfile]) if options[:logfile].nil? && Shoryuken.options[:logfile]
+      Shoryuken.logger.level = Logger::DEBUG if options[:verbose].nil? && Shoryuken.options[:verbose]
     end
 
     def load_rails


### PR DESCRIPTION
When I use `Shoryuken::EnvironmentLoader#load` in Rails initializer like this,

```ruby
Shoryuken::EnvironmentLoader.load(config_file: "config/shoryuken.yml")
```
and set log file in `shoryuken.yml`:

```yaml
verbose: true
logfile: ./log/shoryuken.log
```
I got shoryuken's log in stdout.

```
2016-02-15T05:39:34Z 12757 TID-ovebvg79c WARN: No worker supplied for 'crowdworks-dev-copy-check-queue'
2016-02-15T05:39:47Z 12757 TID-ovebvg79c INFO: Rails environment loaded
2016-02-15T05:39:47Z 12757 TID-ovebvg79c DEBUG: Firing 'startup' lifecycle event
2016-02-15T05:39:47Z 12757 TID-oved00mis INFO: Starting
```

`EnvironmentLoader` ignore log file settings despite the specified in `shoryuken.yml`, because `EnvironmentLoader#load` initialize logger before parse YAML file.
https://github.com/phstc/shoryuken/blob/master/lib/shoryuken/environment_loader.rb#L20

And it don't reset logger after read YAML file.

So, I change call flow about `initialize_logger`, and fix `initialize_logger` to check log settings from YAML file.

