### PR TITLE
Update active_job_adapter.rb

### DIFF
--- a/lib/shoryuken/extensions/active_job_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_adapter.rb
@@ -26,7 +26,7 @@ module ActiveJob
         end
 
         def enqueue_at(job, timestamp)
-          instance.enqueue(job, timestamp)
+          instance.enqueue_at(job, timestamp)
         end
       end
 


### PR DESCRIPTION
a typo in the method name