### PR TITLE
add shoryukenctl control executable for shutting down

### DIFF
--- a/bin/shoryukenctl
+++ b/bin/shoryukenctl
@@ -1,0 +1,99 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+
+class Shoryukenctl
+  DEFAULT_KILL_TIMEOUT = 10
+
+  attr_reader :stage, :pidfile, :kill_timeout
+
+  def self.print_usage
+    puts "#{File.basename($0)} - stop a Shoryuken process from the command line."
+    puts
+    puts "Usage: #{File.basename($0)} <command> <pidfile> <kill_timeout>"
+    puts " where <command> is either 'quiet' or 'stop'"
+    puts "       <pidfile> is path to a pidfile"
+    puts "       <kill_timeout> is number of seconds to wait until Shoryuken exits"
+    puts "       (default: #{Shoryukenctl::DEFAULT_KILL_TIMEOUT}), after which Shoryuken will be KILL'd"
+    puts
+    puts "Be sure to set the kill_timeout LONGER than Shoryuken's -t timeout.  If you want"
+    puts "to wait 60 seconds for jobs to finish, use `sidekiq -t 60` and `sidekiqctl stop"
+    puts " path_to_pidfile 61`"
+    puts
+  end
+
+  def initialize(stage, pidfile, timeout)
+    @stage = stage
+    @pidfile = pidfile
+    @kill_timeout = timeout
+
+    done('No pidfile given', :error) if !pidfile
+    done("Pidfile #{pidfile} does not exist", :warn) if !File.exist?(pidfile)
+    done('Invalid pidfile content', :error) if pid == 0
+
+    fetch_process
+
+    begin
+      send(stage)
+    rescue NoMethodError
+      done "Invalid command: #{stage}", :error
+    end
+  end
+
+  def fetch_process
+    Process.kill(0, pid)
+  rescue Errno::ESRCH
+    done "Process doesn't exist", :error
+  # We were not allowed to send a signal, but the process must have existed
+  # when Process.kill() was called.
+  rescue Errno::EPERM
+    return pid
+  end
+
+  def done(msg, error = nil)
+    puts msg
+    exit(exit_signal(error))
+  end
+
+  def exit_signal(error)
+    (error == :error) ? 1 : 0
+  end
+
+  def pid
+    @pid ||= File.read(pidfile).to_i
+  end
+
+  def quiet
+    `kill -USR1 #{pid}`
+  end
+
+  def stop
+    `kill -TERM #{pid}`
+    kill_timeout.times do
+      begin
+        Process.kill(0, pid)
+      rescue Errno::ESRCH
+        FileUtils.rm_f pidfile
+        done 'Shoryuken shut down gracefully.'
+      rescue Errno::EPERM
+        done 'Not permitted to shut down Shoryuken.'
+      end
+      sleep 1
+    end
+    `kill -9 #{pid}`
+    FileUtils.rm_f pidfile
+    done 'Shoryuken shut down forcefully.'
+  end
+  alias_method :shutdown, :stop
+end
+
+if ARGV.length < 2
+  Shoryukenctl.print_usage
+else
+  stage = ARGV[0]
+  pidfile = ARGV[1]
+  timeout = ARGV[2].to_i
+  timeout = Shoryukenctl::DEFAULT_KILL_TIMEOUT if timeout == 0
+
+  Shoryukenctl.new(stage, pidfile, timeout)
+end

--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'LGPL-3.0'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = %w[shoryuken]
+  spec.executables   = %w[shoryuken shoryukenctl]
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
I've just set up the deployment for some servers with Shoryuken processes using the sidekiqctl script to send shutdown signals. Here I just copied the script and s/Sidekiq/Shoryuken since the signals are the same. Thought it might be useful for others :smile: 