### PR TITLE
Fix option initialization for queues

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -112,7 +112,7 @@ module Shoryuken
     end
 
     def parse_cli_args(argv)
-      opts = { queues: [] }
+      opts = {}
 
       @parser = OptionParser.new do |o|
         o.on '-c', '--concurrency INT', 'Processor threads to use' do |arg|
@@ -125,6 +125,7 @@ module Shoryuken
 
         o.on '-q', '--queue QUEUE[,WEIGHT]...', 'Queues to process with optional weights' do |arg|
           queue, weight = arg.split(',')
+          opts[:queues] = [] unless opts[:queues]
           opts[:queues] << [queue, weight]
         end
 

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -15,8 +15,7 @@ module Shoryuken
     end
 
     def load
-      Shoryuken.options.merge!(config_file_options)
-      Shoryuken.options.merge!(options)
+      initialize_options
       initialize_logger
       load_rails if options[:rails]
       merge_cli_defined_queues
@@ -30,6 +29,11 @@ module Shoryuken
     end
 
     private
+
+    def initialize_options
+      Shoryuken.options.merge!(config_file_options)
+      Shoryuken.options.merge!(options)
+    end
 
     def config_file_options
       return {} unless (path = options[:config_file])
@@ -92,7 +96,9 @@ module Shoryuken
         require File.expand_path('config/environment.rb')
       end
 
-      Shoryuken.options.merge!(config_file_options)
+      # Reload options with Rails environment (see PR #195)
+      initialize_options
+
       Shoryuken.logger.info { 'Rails environment loaded' }
     end
 

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -92,6 +92,7 @@ module Shoryuken
         require File.expand_path('config/environment.rb')
       end
 
+      Shoryuken.options.merge!(config_file_options)
       Shoryuken.logger.info { 'Rails environment loaded' }
     end
 


### PR DESCRIPTION
This corrects option initialization when invoking `shoryuken` via the command line, and also fixes setting configuration options using the Rails environment with gems like dotenv.

Since PR #191, queues from the configuration file were being overwritten by the command line's default options—effectively being ignored.