### PR TITLE
Fix initialization when the Load Rails option is specified

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -15,9 +15,9 @@ module Shoryuken
     end
 
     def load
+      load_rails if options[:rails]
       initialize_options
       initialize_logger
-      load_rails if options[:rails]
       merge_cli_defined_queues
       prefix_active_job_queue_names
       parse_queues
@@ -95,11 +95,6 @@ module Shoryuken
         require 'shoryuken/extensions/active_job_adapter' if defined?(::ActiveJob)
         require File.expand_path('config/environment.rb')
       end
-
-      # Reload options with Rails environment (see PR #195)
-      initialize_options
-
-      Shoryuken.logger.info { 'Rails environment loaded' }
     end
 
     def merge_cli_defined_queues


### PR DESCRIPTION
I want to use gems like SettingsLogic with Rails environements in the Shoryuken configuration file.
So, Rails must be loaded before loading the Shoryuken configuration file.