### PR TITLE
require 'rails' before initialize config

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -15,6 +15,7 @@ module Shoryuken
     end
 
     def load
+      require 'rails' if options[:rails]
       initialize_options
       initialize_logger
       load_rails if options[:rails]
@@ -82,7 +83,6 @@ module Shoryuken
     def load_rails
       # Adapted from: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb
 
-      require 'rails'
       if ::Rails::VERSION::MAJOR < 4
         require File.expand_path('config/environment.rb')
         ::Rails.application.eager_load!


### PR DESCRIPTION
In order to fix this👇  (I guess it's been since https://github.com/phstc/shoryuken/pull/191 )

config/shoryuken.yml
```
queues:
  - [<%= Rails.env %>-foo-bar-queue, 2]
```

```
% bundle exec shoryuken -R -C config/shoryuken.yml
uninitialized constant Rails
...
```