### PR TITLE
Allow Shoryuken AWS credentials to be overridden for job enqueuing

### DIFF
--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -31,10 +31,13 @@ module Shoryuken
 
       def aws_client_options(service_endpoint_key)
         environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
-        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key] || environment_endpoint
-        options = {}
-        options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
-        options
+        aws_options = Shoryuken.options[:aws]
+        explicit_endpoint = aws_options[service_endpoint_key] || environment_endpoint
+        Hash.new.tap do |options|
+          options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
+          options[:access_key_id] = aws_options[:access_key_id] unless aws_options[:access_key_id].nil?
+          options[:secret_access_key] = aws_options[:secret_access_key] unless aws_options[:secret_access_key].nil?
+        end
       end
     end
   end

--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -2,6 +2,7 @@ module Shoryuken
   module Middleware
     module Server
       class ExponentialBackoffRetry
+        MODIFIER_BASE = 10
         include Util
 
         def call(worker, queue, sqs_msg, body)
@@ -31,6 +32,9 @@ module Shoryuken
                      else
                        retry_intervals.last
                      end
+          random_modifier = (rand * interval / MODIFIER_BASE).floor
+          interval += random_modifier
+
 
           # Visibility timeouts are limited to a total 12 hours, starting from the receipt of the message.
           # We calculate the maximum timeout by subtracting the amount of time since the receipt of the message.


### PR DESCRIPTION
We use more than one set of keys for Aws.  While ```config/shoryuken.yml``` works well for initializing workers to use alternate Aws credentials, in order to enqueue jobs correctly from the web worker, we needed to override the credentials that ```Aws::SQS::Client``` uses.

This allows us to specify in ```config/initializers/shoryuken.rb```
```ruby
Shoryuken.options[:aws] = { 
  access_key_id: ENV['AWS_API_ACCESS_KEY_ID'],
  secret_access_key: ENV['AWS_API_SECRET_ACCESS_KEY']
}
```