### PR TITLE
Fix NameError exception in AutoExtendVisibility

### DIFF
--- a/lib/shoryuken/middleware/server/auto_extend_visibility.rb
+++ b/lib/shoryuken/middleware/server/auto_extend_visibility.rb
@@ -1,3 +1,5 @@
+require 'celluloid' unless defined?(Celluloid)
+
 module Shoryuken
   module Middleware
     module Server


### PR DESCRIPTION
When execute command `bundle exec shoryuken -C config/shoryuken.yml --rails`.

> uninitialized constant Shoryuken::Middleware::Server::AutoExtendVisibility::MessageVisibilityExtender::Celluloid (NameError)
