### PR TITLE
Fix auto extend error when using an ActiveJob wrapper

### DIFF
--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -42,7 +42,8 @@ module Shoryuken
           && !sqs_msg.is_a?(Array) \
           && sqs_msg.message_attributes \
           && sqs_msg.message_attributes['shoryuken_class'] \
-          && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s
+          && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s \
+          && body
 
         "ActiveJob/#{body['job_class']}"
       else

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -42,8 +42,8 @@ module Shoryuken
           && !sqs_msg.is_a?(Array) \
           && sqs_msg.message_attributes \
           && sqs_msg.message_attributes['shoryuken_class'] \
-          && sqs_msg.message_attributes['shoryuken_class'][:string_value] == \
-            ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s \
+          && sqs_msg.message_attributes['shoryuken_class'][:string_value] \
+          == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s \
           && body
 
         "ActiveJob/#{body['job_class']}"

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -42,7 +42,8 @@ module Shoryuken
           && !sqs_msg.is_a?(Array) \
           && sqs_msg.message_attributes \
           && sqs_msg.message_attributes['shoryuken_class'] \
-          && sqs_msg.message_attributes['shoryuken_class'][:string_value] == ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s \
+          && sqs_msg.message_attributes['shoryuken_class'][:string_value] == \
+            ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper.to_s \
           && body
 
         "ActiveJob/#{body['job_class']}"


### PR DESCRIPTION
When using auto extend

> ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper
Could not auto extend the message ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper/<queue_name>/<message> visibility timeout. Error: undefined method `[]' for nil:NilClass