### PR TITLE
Make fetcher pause interval configurable

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -119,6 +119,10 @@ module Shoryuken
           opts[:concurrency] = Integer(arg)
         end
 
+        o.on '-i', '--fetcher-pause-interval DECIMAL', 'Interval to pause fetching when all workers are busy' do |arg|
+          opts[:fetcher_pause_interval] = Float(arg)
+        end
+
         o.on '-d', '--daemon', 'Daemonize process' do |arg|
           opts[:daemon] = arg
         end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -12,7 +12,17 @@ module Shoryuken
 
     def initialize(condvar)
       @count = Shoryuken.options[:concurrency] || 25
-      raise(ArgumentError, "Concurrency value #{@count} is invalid, it needs to be a positive number") unless @count > 0
+      @fetcher_pause_interval = Shoryuken.options[:fetcher_pause_interval] || 1
+
+      unless @count > 0
+        raise(ArgumentError, "Concurrency value #{@count} is invalid, it needs to be a positive number")
+      end
+
+      if @fetcher_pause_interval < 0
+        message = "Fetcher pause interval value #{@fetcher_pause_interval} is invalid, it cannot be negative"
+        raise(ArgumentError, message)
+      end
+
       @queues = Shoryuken.queues.dup.uniq
       @finished = condvar
 
@@ -122,16 +132,15 @@ module Shoryuken
       after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
     end
 
-
     def dispatch
       return if stopped?
 
       logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{unparse_queues(@queues)}" }
 
       if @ready.empty?
-        logger.debug { 'Pausing fetcher, because all processors are busy' }
+        logger.debug { 'Pausing fetcher for #{@fetcher_pause_interval} seconds, because all processors are busy' }
 
-        after(1) { dispatch }
+        after(@fetcher_pause_interval) { dispatch }
 
         return
       end

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe Shoryuken::Manager do
   describe 'Invalid concurrency setting' do
     it 'raises ArgumentError if concurrency is not positive number' do
       Shoryuken.options[:concurrency] = -1
-      expect { Shoryuken::Manager.new(nil) }
-        .to raise_error(ArgumentError, 'Concurrency value -1 is invalid, it needs to be a positive number')
+      expect { Shoryuken::Manager.new(nil) }.
+        to raise_error(ArgumentError, 'Concurrency value -1 is invalid, it needs to be a positive number')
     end
 
+  end
+
+  describe 'Invalid fetch pause interval setting' do
+    it 'raises ArgumentError if fetcher pause interval is not positive number' do
+      Shoryuken.options[:fetcher_pause_interval] = -1
+      expect { Shoryuken::Manager.new(nil) }.
+        to raise_error(ArgumentError, 'Fetcher pause interval value -1 is invalid, it cannot be negative')
+    end
   end
 
   describe 'Auto Scaling' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ RSpec.configure do |config|
 
     Shoryuken.queues.clear
 
+    Shoryuken.options[:fetcher_pause_interval] = 1
     Shoryuken.options[:concurrency] = 1
     Shoryuken.options[:delay]       = 1
     Shoryuken.options[:timeout]     = 1


### PR DESCRIPTION
The fetcher currently pauses for one second when all processes are busy.  When running in single-threaded mode this effectively means we can only process one job per second.   This PR allows us to configure the pause interval (eg: 0.1 for 100ms) instead of using the hardcoded value.