### PR TITLE
Reduce timeout wait time

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -68,6 +68,7 @@ module Shoryuken
 
         if stopped?
           processor.terminate if processor.alive?
+          return after(0) { @finished.signal } if @busy.empty?
         else
           @ready << processor
         end
@@ -81,7 +82,9 @@ module Shoryuken
         @threads.delete(processor.object_id)
         @busy.delete processor
 
-        unless stopped?
+        if stopped?
+          return after(0) { @finished.signal } if @busy.empty?
+        else
           @ready << build_processor
         end
       end


### PR DESCRIPTION
Fixes that case where:
1. Timeout is set to some big value (slow jobs needs that to avoid excessive retrying)
2. `stop` is received
3. A worker is running so we end in `after(delay)` part of soft/hard shutdown

Current code will wait for exactly `delay` to shut down while it could die after that last worker crashes/finishes.