### PR TITLE
Fix shoryuken loading

### DIFF
--- a/lib/shoryuken/middleware/server/auto_extend_visibility.rb
+++ b/lib/shoryuken/middleware/server/auto_extend_visibility.rb
@@ -1,3 +1,5 @@
+require 'celluloid'
+
 module Shoryuken
   module Middleware
     module Server


### PR DESCRIPTION
With last PR for isolating part of manager to middleware we actually broke shoryuken loading.
Repro steps:
```bash
bundle exec shoryuken -r ./examples/default_worker.rb
```