### PR TITLE
Daemonize before loading environment

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -31,10 +31,11 @@ module Shoryuken
 
       options = parse_cli_args(args)
 
-      EnvironmentLoader.load(options)
-
       daemonize
       write_pid
+
+      EnvironmentLoader.load(options)
+
       load_celluloid
 
       require 'shoryuken/launcher'


### PR DESCRIPTION
Daemonizing forks the process, which kills all other running threads. If your Rails app starts threads during initialization, they will currently be killed almost immediately.

Sidekiq daemonizes before loading Rails:
https://github.com/mperham/sidekiq/blob/v4.1.2/lib/sidekiq/cli.rb#L42-L43
https://github.com/mperham/sidekiq/blob/v4.1.2/lib/sidekiq/cli.rb#L50