### PR TITLE
Lazy load AutoExtendVisibility middleware

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -15,7 +15,6 @@ require 'shoryuken/worker_registry'
 require 'shoryuken/default_worker_registry'
 require 'shoryuken/middleware/chain'
 require 'shoryuken/middleware/server/auto_delete'
-require 'shoryuken/middleware/server/auto_extend_visibility'
 require 'shoryuken/middleware/server/exponential_backoff_retry'
 require 'shoryuken/middleware/server/timing'
 require 'shoryuken/sns_arn'
@@ -140,10 +139,13 @@ module Shoryuken
 
     def default_server_middleware
       Middleware::Chain.new do |m|
+        # middleware requiring Celluloid has to be loaded here, after dameonization has happened
+        require 'shoryuken/middleware/server/auto_extend_visibility'
+        m.add Middleware::Server::AutoExtendVisibility
+
         m.add Middleware::Server::Timing
         m.add Middleware::Server::ExponentialBackoffRetry
         m.add Middleware::Server::AutoDelete
-        m.add Middleware::Server::AutoExtendVisibility
         if defined?(::ActiveRecord::Base)
           require 'shoryuken/middleware/server/active_record'
           m.add Middleware::Server::ActiveRecord

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -34,9 +34,9 @@ module Shoryuken
       daemonize
       write_pid
 
-      EnvironmentLoader.load(options)
-
       load_celluloid
+
+      EnvironmentLoader.load(options)
 
       require 'shoryuken/launcher'
       @launcher = Shoryuken::Launcher.new


### PR DESCRIPTION
Since `auto_extend_visibility` needs Celluloid, we need to load it lazily.
Also, `load_celluloid` is moved before loading environment because:
- it's a system dependency
- does not require anything from environment
- **breaks pretty hard, which means that loading celluloid after daemonization and before load_celluloid could break, even if it should not.**