### PR TITLE
Ouput the backtrace when a processor dies.

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -78,6 +78,7 @@ module Shoryuken
     def processor_died(processor, reason)
       watchdog("Manager#processor_died died") do
         logger.error { "Process died, reason: #{reason}" unless reason.to_s.empty? }
+        reason.backtrace.each { |bt| logger.error { bt } } unless reason.backtrace.nil?
 
         @threads.delete(processor.object_id)
         @busy.delete processor


### PR DESCRIPTION
I couldn't see any obvious reason why the backtraces aren't logged so I thought I'd suggest this.  Let me know if this is contrary to some intention you had/choice you made.
