### PR TITLE
Refactor fetcher, polling strategy and manager

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -20,6 +20,7 @@ require 'shoryuken/middleware/server/exponential_backoff_retry'
 require 'shoryuken/middleware/server/timing'
 require 'shoryuken/sns_arn'
 require 'shoryuken/topic'
+require 'shoryuken/polling'
 
 module Shoryuken
   DEFAULTS = {
@@ -32,7 +33,8 @@ module Shoryuken
       startup: [],
       quiet: [],
       shutdown: [],
-    }
+    },
+    polling_strategy: Polling::WeightedRoundRobin,
   }
 
   @@queues = []

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -15,13 +15,12 @@
 
             sqs_msgs = Array(receive_messages(queue, limit))
             logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
-
             logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
-
             sqs_msgs
           rescue => ex
             logger.error { "Error fetching message: #{ex}" }
             logger.error { ex.backtrace.first }
+            []
           end
         end
       end
@@ -39,7 +38,7 @@
 
         options.merge!(queue.options)
 
-        Shoryuken::Client.queues(queue.name).receive_messages options
+        Shoryuken::Client.queues(queue.name).receive_messages(options)
       end
     end
   end

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -9,18 +9,6 @@ module Shoryuken
       @manager = manager
     end
 
-    def receive_messages(queue, limit)
-      # AWS limits the batch size by 10
-      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
-
-      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
-      options[:max_number_of_messages] = limit
-      options[:message_attribute_names] = %w(All)
-      options[:attribute_names] = %w(All)
-
-      Shoryuken::Client.queues(queue).receive_messages options
-    end
-
     def fetch(queue, available_processors)
       watchdog('Fetcher#fetch died') do
         started_at = Time.now
@@ -28,23 +16,23 @@ module Shoryuken
         logger.debug { "Looking for new messages in '#{queue}'" }
 
         begin
-          batch = Shoryuken.worker_registry.batch_receive_messages?(queue)
+          batch = Shoryuken.worker_registry.batch_receive_messages?(queue.name)
           limit = batch ? FETCH_LIMIT : available_processors
 
           if (sqs_msgs = Array(receive_messages(queue, limit))).any?
             logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
 
             if batch
-              @manager.async.assign(queue, patch_sqs_msgs!(sqs_msgs))
+              @manager.async.assign(queue.name, patch_sqs_msgs!(sqs_msgs))
             else
-              sqs_msgs.each { |sqs_msg| @manager.async.assign(queue, sqs_msg) }
+              sqs_msgs.each { |sqs_msg| @manager.async.assign(queue.name, sqs_msg) }
             end
 
-            @manager.async.rebalance_queue_weight!(queue)
+            @manager.async.messages_present(queue)
           else
             logger.debug { "No message found for '#{queue}'" }
 
-            @manager.async.pause_queue!(queue)
+            @manager.async.queue_empty(queue)
           end
 
           logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
@@ -55,10 +43,23 @@ module Shoryuken
 
         @manager.async.dispatch
       end
-
     end
 
     private
+
+    def receive_messages(queue, limit)
+      # AWS limits the batch size by 10
+      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
+
+      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
+      options[:max_number_of_messages] = limit
+      options[:message_attribute_names] = %w(All)
+      options[:attribute_names] = %w(All)
+
+      options.merge!(queue.options)
+
+      Shoryuken::Client.queues(queue.name).receive_messages options
+    end
 
     def patch_sqs_msgs!(sqs_msgs)
       sqs_msgs.instance_eval do

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -1,25 +1,27 @@
-module Shoryuken
-  class Fetcher
-    include Celluloid
-    include Util
+  module Shoryuken
+    class Fetcher
+      include Celluloid
+      include Util
 
-    FETCH_LIMIT = 10
+      FETCH_LIMIT = 10
 
-    def initialize(manager)
-      @manager = manager
-    end
+      def initialize(manager, polling_strategy)
+        @manager = manager
+        @polling_strategy = polling_strategy
+        @delay = Shoryuken.options[:delay].to_f
+      end
 
-    def fetch(queue, available_processors)
-      watchdog('Fetcher#fetch died') do
-        started_at = Time.now
+      def fetch(queue, available_processors)
+        watchdog('Fetcher#fetch died') do
+          started_at = Time.now
 
-        logger.debug { "Looking for new messages in '#{queue}'" }
+          logger.debug { "Looking for new messages in '#{queue}'" }
 
-        begin
-          batch = Shoryuken.worker_registry.batch_receive_messages?(queue.name)
-          limit = batch ? FETCH_LIMIT : available_processors
+          begin
+            batch = Shoryuken.worker_registry.batch_receive_messages?(queue.name)
+            limit = batch ? FETCH_LIMIT : available_processors
 
-          if (sqs_msgs = Array(receive_messages(queue, limit))).any?
+            sqs_msgs = Array(receive_messages(queue, limit))
             logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
 
             if batch
@@ -28,47 +30,50 @@ module Shoryuken
               sqs_msgs.each { |sqs_msg| @manager.async.assign(queue.name, sqs_msg) }
             end
 
-            @manager.async.messages_present(queue)
-          else
-            logger.debug { "No message found for '#{queue}'" }
+            @polling_strategy.messages_found(queue, sqs_msgs.size)
 
-            @manager.async.queue_empty(queue)
+            logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
+          rescue => ex
+            logger.error { "Error fetching message: #{ex}" }
+            logger.error { ex.backtrace.first }
           end
 
-          logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
-        rescue => ex
-          logger.error { "Error fetching message: #{ex}" }
-          logger.error { ex.backtrace.first }
-        end
-
-        @manager.async.dispatch
-      end
-    end
-
-    private
-
-    def receive_messages(queue, limit)
-      # AWS limits the batch size by 10
-      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
-
-      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
-      options[:max_number_of_messages] = limit
-      options[:message_attribute_names] = %w(All)
-      options[:attribute_names] = %w(All)
-
-      options.merge!(queue.options)
-
-      Shoryuken::Client.queues(queue.name).receive_messages options
-    end
-
-    def patch_sqs_msgs!(sqs_msgs)
-      sqs_msgs.instance_eval do
-        def message_id
-          "batch-with-#{size}-messages"
+          @manager.async.dispatch
         end
       end
 
-      sqs_msgs
+      def next_queue(*args)
+        @polling_strategy.next_queue(*args)
+      end
+
+      def active_queues(*args)
+        @polling_strategy.active_queues(*args)
+      end
+
+      private
+
+      def receive_messages(queue, limit)
+        # AWS limits the batch size by 10
+        limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
+
+        options = (Shoryuken.options[:aws][:receive_message] || {}).dup
+        options[:max_number_of_messages] = limit
+        options[:message_attribute_names] = %w(All)
+        options[:attribute_names] = %w(All)
+
+        options.merge!(queue.options)
+
+        Shoryuken::Client.queues(queue.name).receive_messages options
+      end
+
+      def patch_sqs_msgs!(sqs_msgs)
+        sqs_msgs.instance_eval do
+          def message_id
+            "batch-with-#{size}-messages"
+          end
+        end
+
+        sqs_msgs
+      end
     end
   end
-end

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -1,44 +1,44 @@
-  module Shoryuken
-    class Fetcher
-      include Util
+module Shoryuken
+  class Fetcher
+    include Util
 
-      FETCH_LIMIT = 10
+    FETCH_LIMIT = 10
 
-      def fetch(queue, available_processors)
-        watchdog('Fetcher#fetch died') do
-          started_at = Time.now
+    def fetch(queue, available_processors)
+      watchdog('Fetcher#fetch died') do
+        started_at = Time.now
 
-          logger.debug { "Looking for new messages in '#{queue}'" }
+        logger.debug { "Looking for new messages in '#{queue}'" }
 
-          begin
-            limit = available_processors > FETCH_LIMIT ? FETCH_LIMIT : available_processors
+        begin
+          limit = available_processors > FETCH_LIMIT ? FETCH_LIMIT : available_processors
 
-            sqs_msgs = Array(receive_messages(queue, limit))
-            logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
-            logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
-            sqs_msgs
-          rescue => ex
-            logger.error { "Error fetching message: #{ex}" }
-            logger.error { ex.backtrace.first }
-            []
-          end
+          sqs_msgs = Array(receive_messages(queue, limit))
+          logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
+          logger.debug { "Fetcher for '#{queue}' completed in #{elapsed(started_at)} ms" }
+          sqs_msgs
+        rescue => ex
+          logger.error { "Error fetching message: #{ex}" }
+          logger.error { ex.backtrace.first }
+          []
         end
       end
+    end
 
-      private
+    private
 
-      def receive_messages(queue, limit)
-        # AWS limits the batch size by 10
-        limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
+    def receive_messages(queue, limit)
+      # AWS limits the batch size by 10
+      limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
 
-        options = (Shoryuken.options[:aws][:receive_message] || {}).dup
-        options[:max_number_of_messages] = limit
-        options[:message_attribute_names] = %w(All)
-        options[:attribute_names] = %w(All)
+      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
+      options[:max_number_of_messages] = limit
+      options[:message_attribute_names] = %w(All)
+      options[:attribute_names] = %w(All)
 
-        options.merge!(queue.options)
+      options.merge!(queue.options)
 
-        Shoryuken::Client.queues(queue.name).receive_messages(options)
-      end
+      Shoryuken::Client.queues(queue.name).receive_messages(options)
     end
   end
+end

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -10,18 +10,16 @@ module Shoryuken
     def initialize
       @condvar = Celluloid::Condition.new
       @manager = Shoryuken::Manager.new_link(@condvar)
-      polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
-      @fetcher = Shoryuken::Fetcher.new_link(manager, polling_strategy)
 
       @done = false
 
-      manager.fetcher = @fetcher
+      manager.fetcher = Shoryuken::Fetcher.new
+      manager.polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
     end
 
     def stop(options = {})
       watchdog('Launcher#stop') do
         @done = true
-        @fetcher.terminate if @fetcher.alive?
 
         manager.async.stop(shutdown: !!options[:shutdown], timeout: Shoryuken.options[:timeout])
         @condvar.wait

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -10,7 +10,8 @@ module Shoryuken
     def initialize
       @condvar = Celluloid::Condition.new
       @manager = Shoryuken::Manager.new_link(@condvar)
-      @fetcher = Shoryuken::Fetcher.new_link(manager)
+      polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
+      @fetcher = Shoryuken::Fetcher.new_link(manager, polling_strategy)
 
       @done = false
 

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -9,6 +9,8 @@ module Shoryuken
     attr_accessor :fetcher
     attr_accessor :polling_strategy
 
+    exclusive :dispatch
+
     trap_exit :processor_died
 
     BATCH_LIMIT = 10
@@ -72,6 +74,7 @@ module Shoryuken
           return after(0) { @finished.signal } if @busy.empty?
         else
           @ready << processor
+          async.dispatch
         end
       end
     end
@@ -87,6 +90,7 @@ module Shoryuken
           return after(0) { @finished.signal } if @busy.empty?
         else
           @ready << build_processor
+          async.dispatch
         end
       end
     end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -143,13 +143,13 @@ module Shoryuken
 
     def dispatch_batch(queue)
       batch = fetcher.fetch(queue, BATCH_LIMIT)
-      self.async.assign(queue.name, patch_batch!(batch))
+      assign(queue.name, patch_batch!(batch))
       polling_strategy.messages_found(queue.name, batch.size)
     end
 
     def dispatch_single_messages(queue)
       messages = fetcher.fetch(queue, @ready.size)
-      messages.each { |message| self.async.assign(queue.name, message) }
+      messages.each { |message| assign(queue.name, message) }
       polling_strategy.messages_found(queue.name, messages.size)
     end
 

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -107,14 +107,8 @@ module Shoryuken
       end
 
       queue = polling_strategy.next_queue
-      if queue == nil 
+      if queue == nil
         logger.debug { 'Pausing fetcher, because all queues are paused' }
-        after(1) { dispatch }
-        return
-      end
-
-      unless defined?(::ActiveJob) || Shoryuken.worker_registry.workers(queue.name).any?
-        logger.debug { "Pausing fetcher, because of no registered workers for queue #{queue}" }
         after(1) { dispatch }
         return
       end
@@ -143,14 +137,14 @@ module Shoryuken
 
     def dispatch_batch(queue)
       batch = fetcher.fetch(queue, BATCH_LIMIT)
-      assign(queue.name, patch_batch!(batch))
       polling_strategy.messages_found(queue.name, batch.size)
+      assign(queue.name, patch_batch!(batch))
     end
 
     def dispatch_single_messages(queue)
       messages = fetcher.fetch(queue, @ready.size)
-      messages.each { |message| assign(queue.name, message) }
       polling_strategy.messages_found(queue.name, messages.size)
+      messages.each { |message| assign(queue.name, message) }
     end
 
     def batched_queue?(queue)

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -114,13 +114,13 @@ module Shoryuken
     end
 
     def queue_empty(queue)
-      return if Shoryuken.options[:delay].to_f <= 0
+      return if delay <= 0
 
-      logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty" }
+      logger.debug { "Pausing '#{queue}' for #{delay} seconds, because it's empty" }
 
       @polling_strategy.pause(queue)
 
-      after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
+      after(delay) { async.restart_queue!(queue) }
     end
 
 
@@ -152,6 +152,10 @@ module Shoryuken
 
     private
 
+    def delay
+      Shoryuken.options[:delay].to_f
+    end
+
     def build_processor
       processor = Processor.new_link(current_actor)
       processor.proxy_id = processor.object_id
@@ -178,13 +182,13 @@ module Shoryuken
 
       return nil unless queue
 
-      if queue && (not defined?(::ActiveJob) and Shoryuken.worker_registry.workers(queue.name).empty?)
+      if queue && (!defined?(::ActiveJob) && Shoryuken.worker_registry.workers(queue.name).empty?)
         # when no worker registered pause the queue to avoid endless recursion
-        logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered" }
+        logger.debug { "Pausing '#{queue}' for #{delay} seconds, because no workers registered" }
 
         @polling_strategy.pause(queue)
 
-        after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
+        after(delay) { async.restart_queue!(queue) }
 
         queue = next_queue
       end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -107,7 +107,7 @@ module Shoryuken
       end
 
       queue = polling_strategy.next_queue
-      if queue == nil
+      if queue.nil?
         logger.debug { 'Pausing fetcher, because all queues are paused' }
         after(1) { dispatch }
         return
@@ -115,7 +115,7 @@ module Shoryuken
 
       batched_queue?(queue) ? dispatch_batch(queue) : dispatch_single_messages(queue)
 
-      self.async.dispatch
+      async.dispatch
     end
 
     def real_thread(proxy_id, thr)

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -1,5 +1,4 @@
 require 'shoryuken/processor'
-require 'shoryuken/polling'
 require 'shoryuken/fetcher'
 
 module Shoryuken
@@ -15,7 +14,6 @@ module Shoryuken
       @count = Shoryuken.options[:concurrency] || 25
       raise(ArgumentError, "Concurrency value #{@count} is invalid, it needs to be a positive number") unless @count > 0
       @queues = Shoryuken.queues.dup.uniq
-      @polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
       @finished = condvar
 
       @done = false
@@ -107,43 +105,31 @@ module Shoryuken
       end
     end
 
-    def messages_present(queue)
-      watchdog('Manager#messages_present died') do
-        @polling_strategy.messages_present(queue)
-      end
-    end
-
-    def queue_empty(queue)
-      return if delay <= 0
-
-      logger.debug { "Pausing '#{queue}' for #{delay} seconds, because it's empty" }
-
-      @polling_strategy.pause(queue)
-
-      after(delay) { async.restart_queue!(queue) }
-    end
-
-
     def dispatch
       return if stopped?
 
-      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{@polling_strategy.active_queues}" }
+      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{@fetcher.active_queues}" }
 
       if @ready.empty?
         logger.debug { 'Pausing fetcher, because all processors are busy' }
-
         after(1) { dispatch }
-
         return
       end
 
-      if (queue = next_queue)
-        @fetcher.async.fetch(queue, @ready.size)
-      else
+      queue = @fetcher.next_queue
+      if queue == nil 
         logger.debug { 'Pausing fetcher, because all queues are paused' }
-
-        @fetcher_paused = true
+        after(1) { dispatch }
+        return
       end
+
+      unless defined?(::ActiveJob) || Shoryuken.worker_registry.workers(queue.name).any?
+        logger.debug { "Pausing fetcher, because of no registered workers for queue #{queue}" }
+        after(1) { dispatch }
+        return
+      end
+
+      @fetcher.async.fetch(queue, @ready.size)
     end
 
     def real_thread(proxy_id, thr)
@@ -160,40 +146,6 @@ module Shoryuken
       processor = Processor.new_link(current_actor)
       processor.proxy_id = processor.object_id
       processor
-    end
-
-    def restart_queue!(queue)
-      return if stopped?
-
-      @polling_strategy.restart(queue)
-
-      if @fetcher_paused
-        logger.debug { 'Restarting fetcher' }
-
-        @fetcher_paused = false
-
-        dispatch
-      end
-    end
-
-    def next_queue
-      # get/remove the first queue in the list
-      queue = @polling_strategy.next_queue
-
-      return nil unless queue
-
-      if queue && (!defined?(::ActiveJob) && Shoryuken.worker_registry.workers(queue.name).empty?)
-        # when no worker registered pause the queue to avoid endless recursion
-        logger.debug { "Pausing '#{queue}' for #{delay} seconds, because no workers registered" }
-
-        @polling_strategy.pause(queue)
-
-        after(delay) { async.restart_queue!(queue) }
-
-        queue = next_queue
-      end
-
-      queue
     end
 
     def soft_shutdown(delay)

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -1,4 +1,5 @@
 require 'shoryuken/processor'
+require 'shoryuken/polling'
 require 'shoryuken/fetcher'
 
 module Shoryuken
@@ -14,6 +15,7 @@ module Shoryuken
       @count = Shoryuken.options[:concurrency] || 25
       raise(ArgumentError, "Concurrency value #{@count} is invalid, it needs to be a positive number") unless @count > 0
       @queues = Shoryuken.queues.dup.uniq
+      @polling_strategy = Shoryuken.options[:polling_strategy].new(Shoryuken.queues)
       @finished = condvar
 
       @done = false
@@ -105,22 +107,18 @@ module Shoryuken
       end
     end
 
-    def rebalance_queue_weight!(queue)
-      watchdog('Manager#rebalance_queue_weight! died') do
-        if (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
-          logger.info { "Increasing '#{queue}' weight to #{current + 1}, max: #{original}" }
-
-          @queues << queue
-        end
+    def messages_present(queue)
+      watchdog('Manager#messages_present died') do
+        @polling_strategy.messages_present(queue)
       end
     end
 
-    def pause_queue!(queue)
-      return if !@queues.include?(queue) || Shoryuken.options[:delay].to_f <= 0
+    def queue_empty(queue)
+      return if Shoryuken.options[:delay].to_f <= 0
 
       logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because it's empty" }
 
-      @queues.delete(queue)
+      @polling_strategy.pause(queue)
 
       after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
     end
@@ -129,7 +127,7 @@ module Shoryuken
     def dispatch
       return if stopped?
 
-      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{unparse_queues(@queues)}" }
+      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{@polling_strategy.active_queues}" }
 
       if @ready.empty?
         logger.debug { 'Pausing fetcher, because all processors are busy' }
@@ -163,50 +161,33 @@ module Shoryuken
     def restart_queue!(queue)
       return if stopped?
 
-      unless @queues.include? queue
-        logger.debug { "Restarting '#{queue}'" }
+      @polling_strategy.restart(queue)
 
-        @queues << queue
+      if @fetcher_paused
+        logger.debug { 'Restarting fetcher' }
 
-        if @fetcher_paused
-          logger.debug { 'Restarting fetcher' }
+        @fetcher_paused = false
 
-          @fetcher_paused = false
-
-          dispatch
-        end
+        dispatch
       end
-    end
-
-    def current_queue_weight(queue)
-      queue_weight(@queues, queue)
-    end
-
-    def original_queue_weight(queue)
-      queue_weight(Shoryuken.queues, queue)
-    end
-
-    def queue_weight(queues, queue)
-      queues.count { |q| q == queue }
     end
 
     def next_queue
-      return nil if @queues.empty?
-
       # get/remove the first queue in the list
-      queue = @queues.shift
+      queue = @polling_strategy.next_queue
 
-      unless defined?(::ActiveJob) ||  !Shoryuken.worker_registry.workers(queue).empty?
+      return nil unless queue
+
+      if queue && (not defined?(::ActiveJob) and Shoryuken.worker_registry.workers(queue.name).empty?)
         # when no worker registered pause the queue to avoid endless recursion
         logger.debug { "Pausing '#{queue}' for #{Shoryuken.options[:delay].to_f} seconds, because no workers registered" }
 
+        @polling_strategy.pause(queue)
+
         after(Shoryuken.options[:delay].to_f) { async.restart_queue!(queue) }
 
-        return next_queue
+        queue = next_queue
       end
-
-      # add queue back to the end of the list
-      @queues << queue
 
       queue
     end

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -7,8 +7,11 @@ module Shoryuken
     include Util
 
     attr_accessor :fetcher
+    attr_accessor :polling_strategy
 
     trap_exit :processor_died
+
+    BATCH_LIMIT = 10
 
     def initialize(condvar)
       @count = Shoryuken.options[:concurrency] || 25
@@ -39,8 +42,6 @@ module Shoryuken
         end
 
         fire_event(:shutdown, true)
-
-        @fetcher.terminate if @fetcher.alive?
 
         logger.info { "Shutting down #{@ready.size} quiet workers" }
 
@@ -94,21 +95,10 @@ module Shoryuken
       @done
     end
 
-    def assign(queue, sqs_msg)
-      watchdog('Manager#assign died') do
-        logger.debug { "Assigning #{sqs_msg.message_id}" }
-
-        processor = @ready.pop
-        @busy << processor
-
-        processor.async.process(queue, sqs_msg)
-      end
-    end
-
     def dispatch
       return if stopped?
 
-      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{@fetcher.active_queues}" }
+      logger.debug { "Ready: #{@ready.size}, Busy: #{@busy.size}, Active Queues: #{polling_strategy.active_queues}" }
 
       if @ready.empty?
         logger.debug { 'Pausing fetcher, because all processors are busy' }
@@ -116,7 +106,7 @@ module Shoryuken
         return
       end
 
-      queue = @fetcher.next_queue
+      queue = polling_strategy.next_queue
       if queue == nil 
         logger.debug { 'Pausing fetcher, because all queues are paused' }
         after(1) { dispatch }
@@ -129,7 +119,9 @@ module Shoryuken
         return
       end
 
-      @fetcher.async.fetch(queue, @ready.size)
+      batched_queue?(queue) ? dispatch_batch(queue) : dispatch_single_messages(queue)
+
+      self.async.dispatch
     end
 
     def real_thread(proxy_id, thr)
@@ -137,6 +129,33 @@ module Shoryuken
     end
 
     private
+
+    def assign(queue, sqs_msg)
+      watchdog('Manager#assign died') do
+        logger.debug { "Assigning #{sqs_msg.message_id}" }
+
+        processor = @ready.pop
+        @busy << processor
+
+        processor.async.process(queue, sqs_msg)
+      end
+    end
+
+    def dispatch_batch(queue)
+      batch = fetcher.fetch(queue, BATCH_LIMIT)
+      self.async.assign(queue.name, patch_batch!(batch))
+      polling_strategy.messages_found(queue.name, batch.size)
+    end
+
+    def dispatch_single_messages(queue)
+      messages = fetcher.fetch(queue, @ready.size)
+      messages.each { |message| self.async.assign(queue.name, message) }
+      polling_strategy.messages_found(queue.name, messages.size)
+    end
+
+    def batched_queue?(queue)
+      Shoryuken.worker_registry.batch_receive_messages?(queue.name)
+    end
 
     def delay
       Shoryuken.options[:delay].to_f
@@ -177,6 +196,16 @@ module Shoryuken
           @finished.signal
         end
       end
+    end
+
+    def patch_batch!(sqs_msgs)
+      sqs_msgs.instance_eval do
+        def message_id
+          "batch-with-#{size}-messages"
+        end
+      end
+
+      sqs_msgs
     end
   end
 end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -27,34 +27,34 @@ module Shoryuken
       def initialize(queues)
         @initial_queues = queues
         @queues = queues.dup.uniq
-      end
-
-      def active_queues
-        unparse_queues(@queues)
+        @paused_queues = []
       end
 
       def next_queue
+        unpause_queues
         queue = @queues.shift
+        return nil if queue == nil
+
         @queues << queue
         QueueConfiguration.new(queue, {})
       end
 
-      def messages_present(queue)
-        return unless (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
+      def messages_found(queue, messages_found)
+        if messages_found == 0
+          pause(queue)
+          return
+        end
 
-        logger.info "Increasing '#{queue}' weight to #{current + 1}, max: #{original}"
-        @queues << queue
+        maximum_weight = maximum_queue_weight(queue)
+        current_weight = current_queue_weight(queue)
+        if maximum_weight > current_weight
+          logger.info { "Increasing '#{queue}' weight to #{current_weight + 1}, max: #{maximum_weight}" }
+          @queues << queue
+        end
       end
 
-      def pause(queue)
-        return unless @queues.delete(queue)
-        logger.debug "Paused '#{queue}'"
-      end
-
-      def restart(queue)
-        return if @queues.include?(queue)
-        logger.debug "Restarting '#{queue}'"
-        @queues << queue
+      def active_queues
+        unparse_queues(@queues)
       end
 
       def ==(other)
@@ -72,11 +72,29 @@ module Shoryuken
 
       private
 
+      def delay
+        Shoryuken.options[:delay].to_f
+      end
+
+      def pause(queue)
+        return unless @queues.delete(queue)
+        @paused_queues << [Time.now + delay, queue]
+        logger.debug "Paused '#{queue}'"
+      end
+      
+      def unpause_queues
+        return if @paused_queues.empty?
+        return if Time.now < @paused_queues.first[0]
+        pause = @paused_queues.shift
+        @queues << pause[1]
+        logger.debug "Unpaused '#{pause[1]}'"
+      end
+
       def current_queue_weight(queue)
         queue_weight(@queues, queue)
       end
 
-      def original_queue_weight(queue)
+      def maximum_queue_weight(queue)
         queue_weight(@initial_queues, queue)
       end
 

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -57,7 +57,7 @@ module Shoryuken
           @queues == other
         else
           if other.respond_to?(:active_queues)
-            self.active_queues == other.active_queues
+            active_queues == other.active_queues
           else
             false
           end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -1,0 +1,82 @@
+module Shoryuken
+  module Polling
+    QueueConfiguration = Struct.new(:name, :options) do
+      def ==(other)
+        case other
+        when String
+          if options.empty?
+            name == other
+          else
+            false
+          end
+        else
+          super
+        end
+      end
+    end
+
+    class WeightedRoundRobin
+      include Util
+
+      def initialize(queues)
+        @initial_queues = queues
+        @queues = queues.dup.uniq
+      end
+
+      def active_queues
+        unparse_queues(@queues)
+      end
+
+      def next_queue
+        queue = @queues.shift
+        @queues << queue
+        QueueConfiguration.new(queue, {})
+      end
+
+      def messages_present(queue)
+        return unless (original = original_queue_weight(queue)) > (current = current_queue_weight(queue))
+
+        logger.info "Increasing '#{queue}' weight to #{current + 1}, max: #{original}"
+        @queues << queue
+      end
+
+      def pause(queue)
+        return unless @queues.delete(queue)
+        logger.debug "Paused '#{queue}'"
+      end
+
+      def restart(queue)
+        return if @queues.include?(queue)
+        logger.debug "Restarting '#{queue}'"
+        @queues << queue
+      end
+
+      def ==(other)
+        case other
+        when Array
+          @queues == other
+        else
+          if other.respond_to?(:active_queues)
+            self.active_queues == other.active_queues
+          else
+            false
+          end
+        end
+      end
+
+      private
+
+      def current_queue_weight(queue)
+        queue_weight(@queues, queue)
+      end
+
+      def original_queue_weight(queue)
+        queue_weight(@initial_queues, queue)
+      end
+
+      def queue_weight(queues, queue)
+        queues.count { |q| q == queue }
+      end
+    end
+  end
+end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -33,7 +33,7 @@ module Shoryuken
       def next_queue
         unpause_queues
         queue = @queues.shift
-        return nil if queue == nil
+        return nil if queue.nil?
 
         @queues << queue
         QueueConfiguration.new(queue, {})
@@ -81,7 +81,7 @@ module Shoryuken
         @paused_queues << [Time.now + delay, queue]
         logger.debug "Paused '#{queue}'"
       end
-      
+ 
       def unpause_queues
         return if @paused_queues.empty?
         return if Time.now < @paused_queues.first[0]

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -1,6 +1,10 @@
 module Shoryuken
   module Polling
     QueueConfiguration = Struct.new(:name, :options) do
+      def hash
+        name.hash
+      end
+
       def ==(other)
         case other
         when String
@@ -13,6 +17,8 @@ module Shoryuken
           super
         end
       end
+
+      alias_method :eql?, :==
     end
 
     class WeightedRoundRobin

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'shoryuken/manager'
 require 'shoryuken/fetcher'
 
-
 describe Shoryuken::Fetcher do
   let(:queue)      { instance_double('Shoryuken::Queue') }
   let(:queue_name) { 'default' }
@@ -13,7 +12,7 @@ describe Shoryuken::Fetcher do
       queue_url: queue_name,
       body: 'test',
       message_id: 'fc754df79cc24c4196ca5996a44b771e',
-    )
+          )
   end
 
   subject { described_class.new }
@@ -21,17 +20,17 @@ describe Shoryuken::Fetcher do
   describe '#fetch' do
     it 'calls Shoryuken::Client to receive messages' do
       expect(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
-      expect(queue).to receive(:receive_messages)
-        .with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All'])
-        .and_return([])
+      expect(queue).to receive(:receive_messages).
+        with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).
+        and_return([])
       subject.fetch(queue_config, 1)
     end
 
     it 'maxes messages to receive to 10 (SQS limit)' do
       allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
-      expect(queue).to receive(:receive_messages)
-        .with(max_number_of_messages: 10, attribute_names: ['All'], message_attribute_names: ['All'])
-        .and_return([])
+      expect(queue).to receive(:receive_messages).
+        with(max_number_of_messages: 10, attribute_names: ['All'], message_attribute_names: ['All']).
+        and_return([])
       subject.fetch(queue_config, 20)
     end
   end

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -2,41 +2,47 @@ require 'spec_helper'
 require 'shoryuken/manager'
 require 'shoryuken/fetcher'
 
+
 describe Shoryuken::Fetcher do
   let(:manager)    { double Shoryuken::Manager }
   let(:queue)      { double Shoryuken::Queue }
   let(:queue_name) { 'default' }
+  let(:queues) { [queue_name] }
   let(:queue_config) { Shoryuken::Polling::QueueConfiguration.new(queue_name, {}) }
+  let(:polling_strategy) { Shoryuken::Polling::WeightedRoundRobin.new(queues)  }
 
   let(:sqs_msg) do
     double Shoryuken::Message,
       queue_url: queue_name,
       body: 'test',
-      message_id: 'fc754df7-9cc2-4c41-96ca-5996a44b771e'
+      message_id: 'fc754df79cc24c4196ca5996a44b771e'
   end
 
-  subject { described_class.new(manager) }
+  subject { described_class.new(manager, polling_strategy) }
 
   before do
     allow(manager).to receive(:async).and_return(manager)
     allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
   end
 
-
   describe '#fetch' do
     it 'calls pause when no message' do
-      allow(queue).to receive(:receive_messages).with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).and_return([])
+      allow(queue).to receive(:receive_messages)
+        .with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All'])
+        .and_return([])
 
-      expect(manager).to receive(:queue_empty).with(queue_config)
+      expect(polling_strategy).to receive(:messages_found).with(queue_config, 0)
       expect(manager).to receive(:dispatch)
 
       subject.fetch(queue_config, 1)
     end
 
     it 'assigns messages' do
-      allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
+      allow(queue).to receive(:receive_messages)
+        .with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All'])
+        .and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_config)
+      expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
       expect(manager).to receive(:assign).with(queue_name, sqs_msg)
       expect(manager).to receive(:dispatch)
 
@@ -46,9 +52,11 @@ describe Shoryuken::Fetcher do
     it 'assigns messages in batch' do
       TestWorker.get_shoryuken_options['batch'] = true
 
-      allow(queue).to receive(:receive_messages).with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
+      allow(queue).to receive(:receive_messages)
+        .with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All'])
+        .and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_config)
+      expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
       expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
       expect(manager).to receive(:dispatch)
 
@@ -59,9 +67,11 @@ describe Shoryuken::Fetcher do
       let(:queue_name) { 'notfound' }
 
       it 'ignores batch' do
-        allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
+        allow(queue).to receive(:receive_messages)
+          .with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All'])
+          .and_return(sqs_msg)
 
-        expect(manager).to receive(:messages_present).with(queue_config)
+        expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
         expect(manager).to receive(:assign).with(queue_name, sqs_msg)
         expect(manager).to receive(:dispatch)
 

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -4,79 +4,35 @@ require 'shoryuken/fetcher'
 
 
 describe Shoryuken::Fetcher do
-  let(:manager)    { double Shoryuken::Manager }
-  let(:queue)      { double Shoryuken::Queue }
+  let(:queue)      { instance_double('Shoryuken::Queue') }
   let(:queue_name) { 'default' }
-  let(:queues) { [queue_name] }
   let(:queue_config) { Shoryuken::Polling::QueueConfiguration.new(queue_name, {}) }
-  let(:polling_strategy) { Shoryuken::Polling::WeightedRoundRobin.new(queues)  }
 
   let(:sqs_msg) do
-    double Shoryuken::Message,
+    double(Shoryuken::Message,
       queue_url: queue_name,
       body: 'test',
-      message_id: 'fc754df79cc24c4196ca5996a44b771e'
+      message_id: 'fc754df79cc24c4196ca5996a44b771e',
+    )
   end
 
-  subject { described_class.new(manager, polling_strategy) }
-
-  before do
-    allow(manager).to receive(:async).and_return(manager)
-    allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
-  end
+  subject { described_class.new }
 
   describe '#fetch' do
-    it 'calls pause when no message' do
-      allow(queue).to receive(:receive_messages)
+    it 'calls Shoryuken::Client to receive messages' do
+      expect(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
+      expect(queue).to receive(:receive_messages)
         .with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All'])
         .and_return([])
-
-      expect(polling_strategy).to receive(:messages_found).with(queue_config, 0)
-      expect(manager).to receive(:dispatch)
-
       subject.fetch(queue_config, 1)
     end
 
-    it 'assigns messages' do
-      allow(queue).to receive(:receive_messages)
-        .with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All'])
-        .and_return(sqs_msg)
-
-      expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
-      expect(manager).to receive(:assign).with(queue_name, sqs_msg)
-      expect(manager).to receive(:dispatch)
-
-      subject.fetch(queue_config, 5)
-    end
-
-    it 'assigns messages in batch' do
-      TestWorker.get_shoryuken_options['batch'] = true
-
-      allow(queue).to receive(:receive_messages)
-        .with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All'])
-        .and_return(sqs_msg)
-
-      expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
-      expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
-      expect(manager).to receive(:dispatch)
-
-      subject.fetch(queue_config, 5)
-    end
-
-    context 'when worker not found' do
-      let(:queue_name) { 'notfound' }
-
-      it 'ignores batch' do
-        allow(queue).to receive(:receive_messages)
-          .with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All'])
-          .and_return(sqs_msg)
-
-        expect(polling_strategy).to receive(:messages_found).with(queue_config, 1)
-        expect(manager).to receive(:assign).with(queue_name, sqs_msg)
-        expect(manager).to receive(:dispatch)
-
-        subject.fetch(queue_config, 5)
-      end
+    it 'maxes messages to receive to 10 (SQS limit)' do
+      allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
+      expect(queue).to receive(:receive_messages)
+        .with(max_number_of_messages: 10, attribute_names: ['All'], message_attribute_names: ['All'])
+        .and_return([])
+      subject.fetch(queue_config, 20)
     end
   end
 end

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -27,7 +27,7 @@ describe Shoryuken::Fetcher do
     it 'calls pause when no message' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).and_return([])
 
-      expect(manager).to receive(:queue_empty).with(queue_name)
+      expect(manager).to receive(:queue_empty).with(queue_config)
       expect(manager).to receive(:dispatch)
 
       subject.fetch(queue_config, 1)
@@ -36,7 +36,7 @@ describe Shoryuken::Fetcher do
     it 'assigns messages' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_config)
       expect(manager).to receive(:assign).with(queue_name, sqs_msg)
       expect(manager).to receive(:dispatch)
 
@@ -48,7 +48,7 @@ describe Shoryuken::Fetcher do
 
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:messages_present).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_config)
       expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
       expect(manager).to receive(:dispatch)
 
@@ -61,7 +61,7 @@ describe Shoryuken::Fetcher do
       it 'ignores batch' do
         allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-        expect(manager).to receive(:messages_present).with(queue_name)
+        expect(manager).to receive(:messages_present).with(queue_config)
         expect(manager).to receive(:assign).with(queue_name, sqs_msg)
         expect(manager).to receive(:dispatch)
 

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -6,6 +6,7 @@ describe Shoryuken::Fetcher do
   let(:manager)    { double Shoryuken::Manager }
   let(:queue)      { double Shoryuken::Queue }
   let(:queue_name) { 'default' }
+  let(:queue_config) { Shoryuken::Polling::QueueConfiguration.new(queue_name, {}) }
 
   let(:sqs_msg) do
     double Shoryuken::Message,
@@ -26,20 +27,20 @@ describe Shoryuken::Fetcher do
     it 'calls pause when no message' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).and_return([])
 
-      expect(manager).to receive(:pause_queue!).with(queue_name)
+      expect(manager).to receive(:queue_empty).with(queue_name)
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 1)
+      subject.fetch(queue_config, 1)
     end
 
     it 'assigns messages' do
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_name)
       expect(manager).to receive(:assign).with(queue_name, sqs_msg)
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 5)
+      subject.fetch(queue_config, 5)
     end
 
     it 'assigns messages in batch' do
@@ -47,11 +48,11 @@ describe Shoryuken::Fetcher do
 
       allow(queue).to receive(:receive_messages).with(max_number_of_messages: described_class::FETCH_LIMIT, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-      expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+      expect(manager).to receive(:messages_present).with(queue_name)
       expect(manager).to receive(:assign).with(queue_name, [sqs_msg])
       expect(manager).to receive(:dispatch)
 
-      subject.fetch(queue_name, 5)
+      subject.fetch(queue_config, 5)
     end
 
     context 'when worker not found' do
@@ -60,11 +61,11 @@ describe Shoryuken::Fetcher do
       it 'ignores batch' do
         allow(queue).to receive(:receive_messages).with(max_number_of_messages: 5, attribute_names: ['All'], message_attribute_names: ['All']).and_return(sqs_msg)
 
-        expect(manager).to receive(:rebalance_queue_weight!).with(queue_name)
+        expect(manager).to receive(:messages_present).with(queue_name)
         expect(manager).to receive(:assign).with(queue_name, sqs_msg)
         expect(manager).to receive(:dispatch)
 
-        subject.fetch(queue_name, 5)
+        subject.fetch(queue_config, 5)
       end
     end
   end

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -4,20 +4,20 @@ require 'shoryuken/manager'
 RSpec.describe Shoryuken::Manager do
   let(:queue1) { 'shoryuken' }
   let(:queue2) { 'uppercut'}
-  let(:queues) { [] }
+  let(:queues) { [queue1, queue2] }
   let(:polling_strategy) { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
-  let(:fetcher) { Shoryuken::Fetcher.new(manager, polling_strategy) }
+  let(:fetcher) { Shoryuken::Fetcher.new }
   let(:condvar) do
     condvar = double(:condvar)
     allow(condvar).to receive(:signal).and_return(nil)
     condvar
   end
-  let(:manager) { Shoryuken::Manager.new(condvar) }
 
-  subject { manager }
+  subject { Shoryuken::Manager.new(condvar) }
 
   before(:each) do
-    manager.fetcher = fetcher
+    subject.fetcher = fetcher
+    subject.polling_strategy = polling_strategy
   end
 
   describe 'Invalid concurrency setting' do

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -1,10 +1,15 @@
 require 'spec_helper'
 require 'shoryuken/manager'
 
+RSpec::Matchers.define :queue_config_of do |expected|
+  match do |actual|
+    actual.name == expected
+  end
+end
+
 RSpec.describe Shoryuken::Manager do
-  let(:queue1) { 'shoryuken' }
-  let(:queue2) { 'uppercut'}
-  let(:queues) { [queue1, queue2] }
+  let(:queue) { 'default' }
+  let(:queues) { [queue] }
   let(:polling_strategy) { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
   let(:fetcher) { Shoryuken::Fetcher.new }
   let(:condvar) do
@@ -12,12 +17,21 @@ RSpec.describe Shoryuken::Manager do
     allow(condvar).to receive(:signal).and_return(nil)
     condvar
   end
+  let(:async_manager) { instance_double(described_class.name) }
+  let(:concurrency) { 1 }
 
   subject { Shoryuken::Manager.new(condvar) }
 
   before(:each) do
+    Shoryuken.options[:concurrency] = concurrency
     subject.fetcher = fetcher
     subject.polling_strategy = polling_strategy
+    allow_any_instance_of(described_class).to receive(:async).and_return(async_manager)
+  end
+
+  after(:each) do
+    Shoryuken.options[:concurrency] = 1
+    TestWorker.get_shoryuken_options['batch'] = false
   end
 
   describe 'Invalid concurrency setting' do
@@ -25,6 +39,53 @@ RSpec.describe Shoryuken::Manager do
       Shoryuken.options[:concurrency] = -1
       expect { Shoryuken::Manager.new(nil) }
         .to raise_error(ArgumentError, 'Concurrency value -1 is invalid, it needs to be a positive number')
+    end
+  end
+
+  describe '#dispatch' do
+    it 'pauses when there are no active queues' do
+      expect(polling_strategy).to receive(:next_queue).and_return(nil)
+      expect_any_instance_of(described_class).to receive(:after)
+      subject.dispatch
+    end
+
+    it 'calls dispatch_batch if worker wants batches' do
+      TestWorker.get_shoryuken_options['batch'] = true
+      expect_any_instance_of(described_class).to receive(:dispatch_batch).with(queue_config_of(queue))
+      expect_any_instance_of(described_class).to receive(:async).and_return(async_manager)
+      expect(async_manager).to receive(:dispatch)
+      subject.dispatch
+    end
+
+    it 'calls dispatch_single_messages if worker wants single messages' do
+      expect_any_instance_of(described_class).to receive(:dispatch_single_messages)
+        .with(queue_config_of(queue))
+      expect(async_manager).to receive(:dispatch)
+      subject.dispatch
+    end
+  end
+
+  describe '#dispatch_batch' do
+    it 'assings batch as a single message' do
+      q = polling_strategy.next_queue
+      messages = [1, 2, 3]
+      expect(fetcher).to receive(:fetch).with(q, described_class::BATCH_LIMIT).and_return(messages)
+      expect_any_instance_of(described_class).to receive(:assign).with(q.name, messages)
+      subject.send(:dispatch_batch, q)
+    end
+  end
+
+  describe '#dispatch_single_messages' do
+    let(:concurrency) { 3 }
+
+    it 'assings messages from batch one by one' do
+      q = polling_strategy.next_queue
+      messages = [1, 2, 3]
+      expect(fetcher).to receive(:fetch).with(q, concurrency).and_return(messages)
+      expect_any_instance_of(described_class).to receive(:assign).with(q.name, 1)
+      expect_any_instance_of(described_class).to receive(:assign).with(q.name, 2)
+      expect_any_instance_of(described_class).to receive(:assign).with(q.name, 3)
+      subject.send(:dispatch_single_messages, q)
     end
   end
 end

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Shoryuken::Manager do
     end
 
     it 'calls dispatch_single_messages if worker wants single messages' do
-      expect_any_instance_of(described_class).to receive(:dispatch_single_messages)
-        .with(queue_config_of(queue))
+      expect_any_instance_of(described_class).to receive(:dispatch_single_messages).
+        with(queue_config_of(queue))
       expect(async_manager).to receive(:dispatch)
       subject.dispatch
     end

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -29,11 +29,11 @@ RSpec.describe Shoryuken::Manager do
       Shoryuken.queues << queue1
       Shoryuken.queues << queue2
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue1, queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
 
-      subject.pause_queue!(queue1)
+      subject.queue_empty(queue1)
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
     end
 
     it 'increases weight' do
@@ -48,18 +48,18 @@ RSpec.describe Shoryuken::Manager do
       Shoryuken.queues << queue1
       Shoryuken.queues << queue2
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue1, queue2]
-      subject.pause_queue!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
+      subject.queue_empty(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1]
 
-      subject.rebalance_queue_weight!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1, queue1, queue1]
+      subject.messages_present(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1, queue1]
     end
 
     it 'adds queue back' do
@@ -78,12 +78,12 @@ RSpec.describe Shoryuken::Manager do
       fetcher = double('Fetcher').as_null_object
       subject.fetcher = fetcher
 
-      subject.pause_queue!(queue1)
-      expect(subject.instance_variable_get('@queues')).to eq [queue2]
+      subject.queue_empty(queue1)
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
 
       sleep 0.5
 
-      expect(subject.instance_variable_get('@queues')).to eq [queue2, queue1]
+      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
     end
   end
 

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -2,10 +2,22 @@ require 'spec_helper'
 require 'shoryuken/manager'
 
 RSpec.describe Shoryuken::Manager do
-  subject do
+  let(:queue1) { 'shoryuken' }
+  let(:queue2) { 'uppercut'}
+  let(:queues) { [] }
+  let(:polling_strategy) { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
+  let(:fetcher) { Shoryuken::Fetcher.new(manager, polling_strategy) }
+  let(:condvar) do
     condvar = double(:condvar)
     allow(condvar).to receive(:signal).and_return(nil)
-    Shoryuken::Manager.new(condvar)
+    condvar
+  end
+  let(:manager) { Shoryuken::Manager.new(condvar) }
+
+  subject { manager }
+
+  before(:each) do
+    manager.fetcher = fetcher
   end
 
   describe 'Invalid concurrency setting' do
@@ -13,110 +25,6 @@ RSpec.describe Shoryuken::Manager do
       Shoryuken.options[:concurrency] = -1
       expect { Shoryuken::Manager.new(nil) }
         .to raise_error(ArgumentError, 'Concurrency value -1 is invalid, it needs to be a positive number')
-    end
-
-  end
-
-  describe 'Auto Scaling' do
-    it 'decreases weight' do
-      queue1 = 'shoryuken'
-      queue2 = 'uppercut'
-
-      Shoryuken.queues.clear
-      # [shoryuken, 2]
-      # [uppercut,  1]
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue2
-
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
-
-      subject.queue_empty(queue1)
-
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
-    end
-
-    it 'increases weight' do
-      queue1 = 'shoryuken'
-      queue2 = 'uppercut'
-
-      Shoryuken.queues.clear
-      # [shoryuken, 3]
-      # [uppercut,  1]
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue2
-
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue1, queue2]
-      subject.queue_empty(queue1)
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
-
-      subject.messages_present(queue1)
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
-
-      subject.messages_present(queue1)
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1]
-
-      subject.messages_present(queue1)
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1, queue1, queue1]
-    end
-
-    it 'adds queue back' do
-      queue1 = 'shoryuken'
-      queue2 = 'uppercut'
-
-      Shoryuken.queues.clear
-      # [shoryuken, 2]
-      # [uppercut,  1]
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue2
-
-      Shoryuken.options[:delay] = 0.1
-
-      fetcher = double('Fetcher').as_null_object
-      subject.fetcher = fetcher
-
-      subject.queue_empty(queue1)
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2]
-
-      sleep 0.5
-
-      expect(subject.instance_variable_get('@polling_strategy')).to eq [queue2, queue1]
-    end
-  end
-
-  describe '#next_queue' do
-    it 'returns queues' do
-      queue1 = 'shoryuken'
-      queue2 = 'uppercut'
-
-      Shoryuken.queues.clear
-
-      Shoryuken.register_worker queue1, TestWorker
-      Shoryuken.register_worker queue2, TestWorker
-
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue2
-
-      expect(subject.send :next_queue).to eq queue1
-      expect(subject.send :next_queue).to eq queue2
-    end
-
-    it 'skips when no worker' do
-      queue1 = 'shoryuken'
-      queue2 = 'uppercut'
-
-      Shoryuken.queues.clear
-
-      Shoryuken.register_worker queue2, TestWorker
-
-      Shoryuken.queues << queue1
-      Shoryuken.queues << queue2
-
-      expect(subject.send :next_queue).to eq queue2
-      expect(subject.send :next_queue).to eq queue2
     end
   end
 end

--- a/spec/shoryuken/middleware/server/auto_delete_spec.rb
+++ b/spec/shoryuken/middleware/server/auto_delete_spec.rb
@@ -55,8 +55,8 @@ describe Shoryuken::Middleware::Server::AutoDelete do
       expect(sqs_queue).to_not receive(:delete_messages)
 
       expect {
-        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'Error' }
-      }.to raise_error(RuntimeError, 'Error')
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' }
+      }.to raise_error('failed')
     end
   end
 end

--- a/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -46,7 +46,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 300)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'retries the job with exponential backoff' do
@@ -56,7 +56,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 1800)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'uses the last retry interval when :receive_count exceeds the size of :retry_intervals' do
@@ -66,7 +66,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 1800)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
 
     it 'limits the visibility timeout to 12 hours from receipt of message' do
@@ -75,7 +75,7 @@ describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       allow(sqs_msg).to receive(:queue){ sqs_queue }
       expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 43198)
 
-      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise } }.not_to raise_error
+      expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
   end
 end

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'shoryuken/polling'
+
+describe Shoryuken::Polling do
+  let(:queue1) { "shoryuken" }
+  let(:queue2) { "uppercut" }
+  let(:queues) { Array.new }
+
+  describe Shoryuken::Polling::WeightedRoundRobin do
+    subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
+
+    it "decreases weight" do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject).to eq [queue1, queue2]
+
+      subject.pause(queue1)
+
+      expect(subject).to eq [queue2]
+    end
+
+    it "increases weight" do
+      # [shoryuken, 3]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject).to eq [queue1, queue2]
+      subject.pause(queue1)
+      expect(subject).to eq [queue2]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1, queue1]
+
+      subject.messages_present(queue1)
+      expect(subject).to eq [queue2, queue1, queue1, queue1]
+    end
+
+    it "cycles" do
+      # [shoryuken, 1]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue2
+
+      popped = []
+
+      (queues.size * 3).times do
+        popped << subject.next_queue
+      end
+
+      expect(popped).to eq(queues * 3)
+    end
+  end
+end

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -1,63 +1,100 @@
 require 'spec_helper'
 require 'shoryuken/polling'
 
-describe Shoryuken::Polling do
+describe Shoryuken::Polling::WeightedRoundRobin do
   let(:queue1) { 'shoryuken' }
   let(:queue2) { 'uppercut' }
   let(:queues) { Array.new }
+  subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
 
-  describe Shoryuken::Polling::WeightedRoundRobin do
-    subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
-
-    it 'decreases weight' do
+  describe '#next_queue' do
+    it 'cycles' do
       # [shoryuken, 2]
       # [uppercut,  1]
       queues << queue1
       queues << queue1
       queues << queue2
 
-      expect(subject).to eq [queue1, queue2]
-
-      subject.pause(queue1)
-
-      expect(subject).to eq [queue2]
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      expect(subject.next_queue).to eq(queue1)
     end
 
-    it 'increases weight' do
-      # [shoryuken, 3]
+    it 'returns nil if there are no active queues' do
+      expect(subject.next_queue).to eq(nil)
+    end
+
+    it 'unpauses queues whose pause is expired' do
+      # [shoryuken, 2]
       # [uppercut,  1]
-      queues << queue1
       queues << queue1
       queues << queue1
       queues << queue2
 
-      expect(subject).to eq [queue1, queue2]
-      subject.pause(queue1)
-      expect(subject).to eq [queue2]
+      allow(subject).to receive(:delay).and_return(10)
 
-      subject.messages_present(queue1)
-      expect(subject).to eq [queue2, queue1]
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
 
-      subject.messages_present(queue1)
-      expect(subject).to eq [queue2, queue1, queue1]
+      # pause the first queue
+      subject.messages_found(queue1, 0)
+      expect(subject.next_queue).to eq(queue2)
 
-      subject.messages_present(queue1)
-      expect(subject).to eq [queue2, queue1, queue1, queue1]
+      now += 5
+      allow(Time).to receive(:now).and_return(now)
+
+      # pause the second queue
+      subject.messages_found(queue2, 0)
+      expect(subject.next_queue).to eq(nil)
+
+      # queue1 should be unpaused now
+      now += 6
+      allow(Time).to receive(:now).and_return(now)
+      expect(subject.next_queue).to eq(queue1)
+
+      # queue1 should be unpaused and added to the end of queues now
+      now += 6
+      allow(Time).to receive(:now).and_return(now)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
     end
+  end
 
-    it 'cycles' do
-      # [shoryuken, 1]
+  describe '#messages_found' do
+    it 'pauses a queue if there are no messages found' do
+      # [shoryuken, 2]
       # [uppercut,  1]
+      queues << queue1
       queues << queue1
       queues << queue2
 
-      popped = []
+      expect(subject).to receive(:pause).with(queue1).and_call_original
+      subject.messages_found(queue1, 0)
+      expect(subject.instance_variable_get(:@queues)).to eq([queue2])
+    end
 
-      (queues.size * 3).times do
-        popped << subject.next_queue
-      end
+    it 'increased the weight if message is found' do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
 
-      expect(popped).to eq(queues * 3)
+      expect(subject.instance_variable_get(:@queues)).to eq([queue1, queue2])
+      subject.messages_found(queue1, 1)
+      expect(subject.instance_variable_get(:@queues)).to eq([queue1, queue2, queue1])
+    end
+
+    it 'respects the maximum queue weight' do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      subject.messages_found(queue1, 1)
+      subject.messages_found(queue1, 1)
+      expect(subject.instance_variable_get(:@queues)).to eq([queue1, queue2, queue1])
     end
   end
 end

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 require 'shoryuken/polling'
 
 describe Shoryuken::Polling do
-  let(:queue1) { "shoryuken" }
-  let(:queue2) { "uppercut" }
+  let(:queue1) { 'shoryuken' }
+  let(:queue2) { 'uppercut' }
   let(:queues) { Array.new }
 
   describe Shoryuken::Polling::WeightedRoundRobin do
     subject { Shoryuken::Polling::WeightedRoundRobin.new(queues) }
 
-    it "decreases weight" do
+    it 'decreases weight' do
       # [shoryuken, 2]
       # [uppercut,  1]
       queues << queue1
@@ -23,7 +23,7 @@ describe Shoryuken::Polling do
       expect(subject).to eq [queue2]
     end
 
-    it "increases weight" do
+    it 'increases weight' do
       # [shoryuken, 3]
       # [uppercut,  1]
       queues << queue1
@@ -45,7 +45,7 @@ describe Shoryuken::Polling do
       expect(subject).to eq [queue2, queue1, queue1, queue1]
     end
 
-    it "cycles" do
+    it 'cycles' do
       # [shoryuken, 1]
       # [uppercut,  1]
       queues << queue1


### PR DESCRIPTION
Simplifying manager, fetcher and polling strategy in order to make whole system easier to understand, test and more performant
- Fetcher became synchronous and quite simple. It became totally unaware of the manager so we finally lost that bidirectional dependency.
- Manager became far slimmer. It lost responsibility of deciding on next queue (moved to polling strategy) and calls fetcher and assign method synchronously for the sake of easier testing.
- Polling strategy it quite simple and can be replaced with something else. WeightedRoundRobin actually implements the old implicit strategy.

I've done some testing locally for next setup
- one 1, two workers
- workers just re-enq the job back to the q
- run OS X 10.11.6, MacBook Pro (Retina, 13-inch, Early 2015)
- run workers for 5 minutes

For concurrency set to 1, throughput increased ~50%.
For concurrency set to 10, throughput increased ~30%.
For concurrency set to 20, throughput increased ~20%.

It's important to note that increase becomes higher if jobs gets faster (shorter).

WDYT @phstc?
