### PR TITLE
Added proof of concept support for DLQ. Should work for both Shoryuke…

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -13,6 +13,7 @@ require 'shoryuken/client'
 require 'shoryuken/worker'
 require 'shoryuken/worker_registry'
 require 'shoryuken/default_worker_registry'
+require 'shoryuken/redrive_policy_registry'
 require 'shoryuken/middleware/chain'
 require 'shoryuken/middleware/server/auto_delete'
 Shoryuken::Middleware::Server.autoload :AutoExtendVisibility, 'shoryuken/middleware/server/auto_extend_visibility'
@@ -37,6 +38,7 @@ module Shoryuken
 
   @@queues = []
   @@worker_registry = DefaultWorkerRegistry.new
+  @@redrive_policy_registry = RedrivePolicyRegistry.new
   @@active_job_queue_name_prefixing = false
 
   class << self
@@ -62,6 +64,10 @@ module Shoryuken
 
     def worker_registry
       @@worker_registry
+    end
+
+    def redrive_policy_registry
+      @@redrive_policy_registry
     end
 
     def active_job_queue_name_prefixing

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -18,8 +18,10 @@ module Shoryuken
         message.message_attributes['shoryuken_class'] &&
         message.message_attributes['shoryuken_class'][:string_value]
 
-      approximate_receive_count = message.attributes['ApproximateReceiveCount'].to_i
-      if approximate_receive_count > 1 && 'ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper' != worker_class
+      # TODO: get rid of this code
+      # it's only here to pick the correct Worker in case of msg redelivery, when AJ is not used.
+      # by clearing the worker_class, the correct worker will be fetched based on the queue name.
+      if !message.is_a?(Array) && message.redelivery? && active_job_woker?(worker_class)
         worker_class = nil
       end
 
@@ -46,6 +48,12 @@ module Shoryuken
 
     def workers(queue)
       [@workers.fetch(queue, [])].flatten
+    end
+
+    private
+
+    def active_job_woker?(worker_class)
+      'ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper' != worker_class
     end
   end
 end

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -18,6 +18,11 @@ module Shoryuken
         message.message_attributes['shoryuken_class'] &&
         message.message_attributes['shoryuken_class'][:string_value]
 
+      approximate_receive_count = message.attributes['ApproximateReceiveCount'].to_i
+      if approximate_receive_count > 1 && 'ActiveJob::QueueAdapters::ShoryukenAdapter::JobWrapper' != worker_class
+        worker_class = nil
+      end
+
       worker_class = (worker_class.constantize rescue nil) || @workers[queue]
 
       worker_class.new

--- a/lib/shoryuken/message.rb
+++ b/lib/shoryuken/message.rb
@@ -66,5 +66,17 @@ module Shoryuken
     def message_attributes
       data.message_attributes
     end
+
+    def approximate_receive_count
+      data.attributes['ApproximateReceiveCount'].to_i
+    end
+
+    def redelivery?
+      approximate_receive_count > 1
+    end
+
+    def queue_name_from_msg
+      JSON.parse(data.body)['queue_name']
+    end
   end
 end

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -19,6 +19,13 @@ module Shoryuken
       ).attributes['VisibilityTimeout'].to_i
     end
 
+    def redrive_policy
+      client.get_queue_attributes(
+        queue_url: url,
+        attribute_names: ['RedrivePolicy']
+      ).attributes['RedrivePolicy']
+    end
+
     def delete_messages(options)
       client.delete_message_batch(options.merge(queue_url: url))
     end

--- a/lib/shoryuken/redrive_policy_registry.rb
+++ b/lib/shoryuken/redrive_policy_registry.rb
@@ -1,0 +1,13 @@
+class RedrivePolicyRegistry
+  def initialize
+    @policy_registry = {}
+  end
+
+  def fetch(message_queue_name)
+    unless @policy_registry[message_queue_name]
+      redrive_policy_json = JSON.parse(Shoryuken::Client.queues(message_queue_name).redrive_policy)
+      @policy_registry[message_queue_name] = redrive_policy_json['maxReceiveCount']
+    end
+    @policy_registry[message_queue_name]
+  end
+end

--- a/spec/shoryuken/default_worker_registry_spec.rb
+++ b/spec/shoryuken/default_worker_registry_spec.rb
@@ -51,7 +51,8 @@ describe Shoryuken::DefaultWorkerRegistry do
       double Shoryuken::Message,
         body: 'test',
         message_attributes: attributes,
-        message_id: SecureRandom.uuid
+        message_id: SecureRandom.uuid,
+        redelivery?: false
     end
 
     context 'a batch of messages is being processed' do

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Shoryuken::Processor do
       body: 'test',
       message_attributes: {},
       message_id: SecureRandom.uuid,
-      receipt_handle: SecureRandom.uuid
+      receipt_handle: SecureRandom.uuid,
+      redelivery?: false
   end
 
   subject { described_class.new(manager) }
@@ -243,7 +244,8 @@ RSpec.describe Shoryuken::Processor do
               string_value: TestWorker.to_s,
               data_type: 'String' }},
               message_id: SecureRandom.uuid,
-              receipt_handle: SecureRandom.uuid
+              receipt_handle: SecureRandom.uuid,
+              redelivery?: false
       end
 
       it 'performs without delete' do


### PR DESCRIPTION
Probably a lot of polishing still needed, but this is a first proof of concept.
There are some tests that are still failing. So, don't merge yet!

For ActiveJob I had to use a convention
batch_worker (consumes from the normal queue)
batch_dlq_worker (I assume the there is a dlq_worker class if there a Redrive policy defined)