### PR TITLE
changing log verbosity

### DIFF
--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -32,7 +32,7 @@ module Shoryuken
           limit = batch ? FETCH_LIMIT : available_processors
 
           if (sqs_msgs = Array(receive_messages(queue, limit))).any?
-            logger.info { "Found #{sqs_msgs.size} messages for '#{queue}'" }
+            logger.debug { "Found #{sqs_msgs.size} messages for '#{queue}'" }
 
             if batch
               @manager.async.assign(queue, patch_sqs_msgs!(sqs_msgs))


### PR DESCRIPTION
for production environment, we dont need to know how much messages we have received. It pollutes the logs specially when we can collect these informations differently (we format logs in our own way)