### PR TITLE
Add aws configuration in 'Shoryuken.configure_server'

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -6,6 +6,7 @@ require 'shoryuken/version'
 require 'shoryuken/core_ext'
 require 'shoryuken/util'
 require 'shoryuken/logging'
+require 'shoryuken/aws_config'
 require 'shoryuken/environment_loader'
 require 'shoryuken/queue'
 require 'shoryuken/message'
@@ -72,6 +73,12 @@ module Shoryuken
       @@active_job_queue_name_prefixing = prefixing
     end
 
+    ##
+    # Configuration for Shoryuken server, use like:
+    #
+    #   Shoryuken.configure_server do |config|
+    #     config.aws = { :sqs_endpoint => '...', :access_key_id: '...', :secret_access_key: '...', region: '...' }
+    #   end
     def configure_server
       yield self if server?
     end
@@ -82,8 +89,14 @@ module Shoryuken
       @server_chain
     end
 
+    ##
+    # Configuration for Shoryuken client, use like:
+    #
+    #   Shoryuken.configure_client do |config|
+    #     config.aws = { :sqs_endpoint => '...', :access_key_id: '...', :secret_access_key: '...', region: '...' }
+    #   end
     def configure_client
-      yield self
+      yield self unless server?
     end
 
     def client_middleware
@@ -116,6 +129,10 @@ module Shoryuken
 
     def on_stop(&block)
       @stop_callback = block
+    end
+
+    def aws=(hash)
+      @aws = Shoryuken::AwsConfig.setup(hash)
     end
 
     # Register a block to run at a point in the Shoryuken lifecycle.

--- a/lib/shoryuken/aws_config.rb
+++ b/lib/shoryuken/aws_config.rb
@@ -6,8 +6,8 @@ module Shoryuken
         @options ||= {}
       end
 
-      def set_options(hash)
-        Shoryuken::AwsConfig.options.merge!(hash)
+      def options=(hash)
+        @options = hash
       end
 
       def setup(hash)
@@ -15,7 +15,7 @@ module Shoryuken
         # when not explicit supplied
         return if hash.empty?
 
-        set_options(hash)
+        self.options = hash
 
         shoryuken_keys = %w(
           account_id

--- a/lib/shoryuken/aws_config.rb
+++ b/lib/shoryuken/aws_config.rb
@@ -1,0 +1,49 @@
+module Shoryuken
+  class AwsConfig
+
+    class << self
+      def options
+        @options ||= {}
+      end
+
+      def set_options(hash)
+        Shoryuken::AwsConfig.options.merge!(hash)
+      end
+
+      def setup(hash)
+        # aws-sdk tries to load the credentials from the ENV variables: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+        # when not explicit supplied
+        return if hash.empty?
+
+        set_options(hash)
+
+        shoryuken_keys = %w(
+          account_id
+          sns_endpoint
+          sqs_endpoint
+          receive_message
+        ).map(&:to_sym)
+
+        aws_options = hash.reject do |k, v|
+          shoryuken_keys.include?(k)
+        end
+
+        # assume credentials based authentication
+        credentials = Aws::Credentials.new(
+          aws_options.delete(:access_key_id),
+          aws_options.delete(:secret_access_key)
+        )
+
+        # but only if the configuration options have valid values
+        aws_options = aws_options.merge(credentials: credentials) if credentials.set?
+
+        if (callback = Shoryuken.aws_initialization_callback)
+          Shoryuken.logger.info { 'Calling Shoryuken.on_aws_initialization block' }
+          callback.call(aws_options)
+        end
+
+        Aws.config = aws_options
+      end
+    end
+  end
+end

--- a/lib/shoryuken/aws_config.rb
+++ b/lib/shoryuken/aws_config.rb
@@ -1,13 +1,11 @@
+# frozen_string_literal: true
 module Shoryuken
   class AwsConfig
-
     class << self
+      attr_writer :options
+
       def options
         @options ||= {}
-      end
-
-      def options=(hash)
-        @options = hash
       end
 
       def setup(hash)
@@ -24,7 +22,7 @@ module Shoryuken
           receive_message
         ).map(&:to_sym)
 
-        aws_options = hash.reject do |k, v|
+        aws_options = hash.reject do |k, _|
           shoryuken_keys.include?(k)
         end
 

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -31,7 +31,7 @@ module Shoryuken
 
       def aws_client_options(service_endpoint_key)
         environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
-        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key] || environment_endpoint
+        explicit_endpoint = Shoryuken::AwsConfig.options[service_endpoint_key] || environment_endpoint
         options = {}
         options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
         options

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -44,34 +44,7 @@ module Shoryuken
     end
 
     def initialize_aws
-      # aws-sdk tries to load the credentials from the ENV variables: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
-      # when not explicit supplied
-      return if Shoryuken.options[:aws].empty?
-
-      shoryuken_keys = %w(
-        account_id
-        sns_endpoint
-        sqs_endpoint
-        receive_message).map(&:to_sym)
-
-      aws_options = Shoryuken.options[:aws].reject do |k, v|
-        shoryuken_keys.include?(k)
-      end
-
-      # assume credentials based authentication
-      credentials = Aws::Credentials.new(
-        aws_options.delete(:access_key_id),
-        aws_options.delete(:secret_access_key))
-
-      # but only if the configuration options have valid values
-      aws_options = aws_options.merge(credentials: credentials) if credentials.set?
-
-      if (callback = Shoryuken.aws_initialization_callback)
-        Shoryuken.logger.info { 'Calling Shoryuken.on_aws_initialization block' }
-        callback.call(aws_options)
-      end
-
-      Aws.config = aws_options
+      Shoryuken::AwsConfig.setup(Shoryuken.options[:aws])
     end
 
     def initialize_logger

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -13,7 +13,7 @@ module Shoryuken
       # AWS limits the batch size by 10
       limit = limit > FETCH_LIMIT ? FETCH_LIMIT : limit
 
-      options = (Shoryuken.options[:aws][:receive_message] || {}).dup
+      options = (Shoryuken::AwsConfig.options[:receive_message] || {}).dup
       options[:max_number_of_messages] = limit
       options[:message_attribute_names] = %w(All)
       options[:attribute_names] = %w(All)

--- a/spec/shoryuken/client_spec.rb
+++ b/spec/shoryuken/client_spec.rb
@@ -26,6 +26,7 @@ describe Shoryuken::Client do
       ENV['AWS_SNS_ENDPOINT'] = sns_endpoint
       ENV['AWS_REGION'] = 'us-east-1'
       Shoryuken.options[:aws] = {}
+      Shoryuken::AwsConfig.options = {}
     end
 
     it 'will use config file settings if set' do

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -45,6 +45,7 @@ describe Shoryuken::Queue do
         end
 
         before do
+          allow(Shoryuken).to receive(:server?).and_return(false)
           Shoryuken.configure_client do |config|
             config.client_middleware do |chain|
               chain.add MyClientMiddleware


### PR DESCRIPTION
I add aws configuration in `Shoryuken.configure_server`, like sidekiq: 
https://github.com/mperham/sidekiq/blob/master/lib/sidekiq.rb#L75-L83

Now, I have to call `EnvironmentLoader.load` in initializer of my Rails application to setup aws configuration. For example:
```ruby
EnvironmentLoader.load(config_file: "config/shoryuken.yml")
```

I want to divide `EnvironmentLoader.load` method, because I try to fix https://github.com/phstc/shoryuken/issues/249.

To fix #249, shoryuken have to read `shoryuken.yml` before `daemonize`, and then load Rails.
So, I want to divide `EnvironmentLoader.load`.

But, now `EnvironmentLoader.load` is used in initializer of user's Rails application, therefore I propose alternate method to configure aws in initializer. That is `Shoryuken.configure_server`.

In sidekiq, user can configure redis information in initializer.
```ruby
Sidekiq.configure_server do |config|
  config.redis = { url: "redis://localhost:6379" }
end

Sidekiq.configure_client do |config|
 config.redis = { url: "redis://localhost:6379" }
end
```

I aim the same way as sidekiq.
```ruby
Shoryuken.configure_server do |config|
  config.aws = { :sqs_endpoint => '...', :access_key_id: '...', :secret_access_key: '...', region: '...' }
end

Shoryuken.configure_client do |config|
  config.aws = { :sqs_endpoint => '...', :access_key_id: '...', :secret_access_key: '...', region: '...' }
end
```