### PR TITLE
Add ability to pass SQS and SNS sdks options directly in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ aws:
     attribute_names:
       - ApproximateReceiveCount
       - SentTimestamp
+sqs:
+  log_level: debug
+sns:
+  log_level: info
 concurrency: 25  # The number of allocated threads to process messages. Default 25
 delay: 25        # The delay in seconds to pause a queue when it's empty. Default 0
 queues:
@@ -127,7 +131,7 @@ queues:
   - [low_priority, 1]
 ```
 
-The ```aws``` section is used to configure both the Aws objects used by Shoryuken internally, and also to set up some Shoryuken-specific config. The Shoryuken-specific keys are listed below, and you can expect any other key defined in that block to be passed on untouched to ```Aws::SQS::Client#initialize```:
+The ```aws``` section is used to configure both the Aws objects used by Shoryuken internally, and also to set up some Shoryuken-specific config. The Shoryuken-specific keys are listed below:
 
 - ```account_id``` is used when generating SNS ARNs
 - ```sns_endpoint``` can be used to explicitly override the SNS endpoint
@@ -135,6 +139,8 @@ The ```aws``` section is used to configure both the Aws objects used by Shoryuke
 - ```receive_message``` can be used to define the options passed to the http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#receive_message-instance_method
 
 The ```sns_endpoint``` and ```sqs_endpoint``` Shoryuken-specific options will also fallback to the environment variables ```AWS_SNS_ENDPOINT``` and ```AWS_SQS_ENDPOINT``` respectively, if they are set.
+
+The ```sqs``` and ```sns``` sections are for keys that will be passed on untouched to ```Aws::SQS::Client#initialize``` and ```Aws::SNS::Client#initialize``` respectively. In the above example the log level of the clients are set explicitly.
 
 ### Configuration (producer side)
 

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -9,7 +9,7 @@ module Shoryuken
       end
 
       def sns
-        @sns ||= Aws::SNS::Client.new(aws_client_options(:sns_endpoint))
+        @sns ||= Aws::SNS::Client.new(aws_client_options(:sns))
       end
 
       def sns_arn
@@ -17,7 +17,7 @@ module Shoryuken
       end
 
       def sqs
-        @sqs ||= Aws::SQS::Client.new(aws_client_options(:sqs_endpoint))
+        @sqs ||= Aws::SQS::Client.new(aws_client_options(:sqs))
       end
 
       def topics(name)
@@ -29,10 +29,11 @@ module Shoryuken
 
       private
 
-      def aws_client_options(service_endpoint_key)
+      def aws_client_options(client_type)
+        service_endpoint_key = "#{client_type}_endpoint".to_sym
         environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
         explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key] || environment_endpoint
-        options = {}
+        options = Shoryuken.options[client_type] || {}
         options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
         options
       end

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -30,9 +30,9 @@ module Shoryuken
       private
 
       def aws_client_options(client_type)
-        service_endpoint_key = "#{client_type}_endpoint".to_sym
-        environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
-        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key] || environment_endpoint
+        service_endpoint_key = "#{client_type}_endpoint"
+        environment_endpoint = ENV["AWS_#{service_endpoint_key.upcase}"]
+        explicit_endpoint = Shoryuken.options[:aws][service_endpoint_key.to_sym] || environment_endpoint
         options = Shoryuken.options[client_type] || {}
         options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
         options

--- a/spec/shoryuken/client_spec.rb
+++ b/spec/shoryuken/client_spec.rb
@@ -55,6 +55,20 @@ describe Shoryuken::Client do
     end
   end
 
+  describe 'SQS/SNS SDK config options' do
+    it 'will use SDK defaults if sections not declared' do
+      load_config_file_by_file_name('shoryuken.yml')
+      expect(described_class.sqs.config.log_level.to_s).to eql('info')
+      expect(described_class.sns.config.log_level.to_s).to eql('info')
+    end
+
+    it 'will use pass through config if declared' do
+      load_config_file_by_file_name('shoryuken_sdk_config.yml')
+      expect(described_class.sqs.config.log_level.to_s).to eql('debug')
+      expect(described_class.sns.config.log_level.to_s).to eql('error')
+    end
+  end
+
   def load_config_file_by_file_name(file_name)
     path_name = file_name ? File.join(File.expand_path('../../..', __FILE__), 'spec', file_name) : nil
     Shoryuken::EnvironmentLoader.load(config_file: path_name)

--- a/spec/shoryuken_sdk_config.yml
+++ b/spec/shoryuken_sdk_config.yml
@@ -1,0 +1,8 @@
+aws:
+  access_key_id:      <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key:  <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region:             us-east-1
+sqs:
+  log_level: debug
+sns:
+  log_level: error


### PR DESCRIPTION
Adds a `sqs:` and `sns:` section to the config (other key names suggestions welcome) that will pass their options through to the `Aws::SQS::Client` and `Aws::SNS::Client` initializers respectively when created.

Includes tests and updated docs.

Also removes the below passage because as far as I can tell this isn't true as `aws_client_options` doesn't look at `Shoryuken.options[:aws]` to create the `options` key?

> and you can expect any other key defined in that block to be passed on untouched to ```Aws::SQS::Client#initialize```
