### PR TITLE
fixes #249 Fix daemonize when don't set logfile in command line option

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -31,10 +31,12 @@ module Shoryuken
 
       options = parse_cli_args(args)
 
+      loader = EnvironmentLoader.setup_options(options)
+
       daemonize(options)
       write_pid(options)
 
-      EnvironmentLoader.load(options)
+      loader.load
 
       load_celluloid
 

--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -33,8 +33,11 @@ module Shoryuken
 
       loader = EnvironmentLoader.setup_options(options)
 
-      daemonize(options)
-      write_pid(options)
+      # When cli args exist, override options in config file
+      Shoryuken.options.merge!(options)
+
+      daemonize(Shoryuken.options)
+      write_pid(Shoryuken.options)
 
       loader.load
 

--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -2,23 +2,29 @@ module Shoryuken
   class EnvironmentLoader
     attr_reader :options
 
-    def self.load(options)
-      new(options).load
+    def self.setup_options(options)
+      instance = new(options)
+      instance.setup_options
+      instance
     end
 
     def self.load_for_rails_console
-      load(config_file: (Rails.root + 'config' + 'shoryuken.yml'))
+      instance = setup_options(config_file: (Rails.root + 'config' + 'shoryuken.yml'))
+      instance.load
     end
 
     def initialize(options)
       @options = options
     end
 
-    def load
-      load_rails if options[:rails]
+    def setup_options
       initialize_options
       initialize_logger
       merge_cli_defined_queues
+    end
+
+    def load
+      load_rails if options[:rails]
       prefix_active_job_queue_names
       parse_queues
       require_workers

--- a/spec/shoryuken/cli_spec.rb
+++ b/spec/shoryuken/cli_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Shoryuken::CLI do
       allow(launcher).to receive(:stop)
     end
 
+    # reset shoryuken options because class variable hold value which is used previous test case
+    after(:each) do
+      Shoryuken.options[:daemon] = nil
+      Shoryuken.options[:logfile] = nil
+    end
+
     it 'does not raise' do
       expect { cli.run([]) }.to_not raise_error
     end
@@ -32,7 +38,7 @@ RSpec.describe Shoryuken::CLI do
       cli.run(['--daemon', '--logfile', '/dev/null'])
     end
 
-    it 'does NOT daemonize with --daemon --logfile' do
+    it 'does NOT daemonize with --logfile' do
       expect(Process).to_not receive(:daemon)
       cli.run(['--logfile', '/dev/null'])
     end

--- a/spec/shoryuken/client_spec.rb
+++ b/spec/shoryuken/client_spec.rb
@@ -58,6 +58,7 @@ describe Shoryuken::Client do
 
   def load_config_file_by_file_name(file_name)
     path_name = file_name ? File.join(File.expand_path('../../..', __FILE__), 'spec', file_name) : nil
-    Shoryuken::EnvironmentLoader.load(config_file: path_name)
+    loader = Shoryuken::EnvironmentLoader.setup_options(config_file: path_name)
+    loader.load
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ end
 
 config_file = File.join(File.expand_path('../..', __FILE__), 'spec', 'shoryuken.yml')
 
-Shoryuken::EnvironmentLoader.load(config_file: config_file)
+Shoryuken::EnvironmentLoader.setup_options(config_file: config_file)
 
 Shoryuken.logger.level = Logger::UNKNOWN
 Celluloid.logger.level = Logger::UNKNOWN


### PR DESCRIPTION
When I didn't give logfile option in command line, shoryuken can't work fine:

```
rails@085a8fd8cf4a:~/app$ bundle exec shoryuken -R -C config/shoryuken.yml -d
You really should set a logfile if you're going to daemonize
/home/rails/app/vendor/bundle/ruby/2.3.0/gems/shoryuken-2.0.11/lib/shoryuken/cli.rb:80:in `daemonize'
/home/rails/app/vendor/bundle/ruby/2.3.0/gems/shoryuken-2.0.11/lib/shoryuken/cli.rb:34:in `run'
/home/rails/app/vendor/bundle/ruby/2.3.0/gems/shoryuken-2.0.11/bin/shoryuken:6:in `<top (required)>'
/home/rails/app/vendor/bundle/ruby/2.3.0/bin/shoryuken:23:in `load'
/home/rails/app/vendor/bundle/ruby/2.3.0/bin/shoryuken:23:in `<main>'
```

In `config/shoryuken.yml`, I wrote logifle option:

``` yaml
verbose: false
concurrency: 20
delay: 25
pidfile: ./tmp/pids/shoryuken.pid
logfile: ./log/shoryuken.log
```

but shoryuken didn't read logfile option.

Current shoryuken source code,
https://github.com/phstc/shoryuken/blob/v2.0.11/lib/shoryuken/cli.rb#L32-L39
call `daemonize` before `EnvironmentLoader.load`, so didn't read logifle option in config file.
That means, it is necessary to call initialize logger before daemonize.

This change intercept old EnvironmentLoader.load, because I reoder method's call to fix daemonize. 
