### PR TITLE
Add AwsConfig.sns and AwsConfig.sqs, and avoid the override of Aws.config

### DIFF
--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -9,7 +9,7 @@ module Shoryuken
       end
 
       def sns
-        @sns ||= Aws::SNS::Client.new(aws_client_options(:sns_endpoint))
+        @sns ||= Shoryuken::AwsConfig.sns
       end
 
       def sns_arn
@@ -17,7 +17,7 @@ module Shoryuken
       end
 
       def sqs
-        @sqs ||= Aws::SQS::Client.new(aws_client_options(:sqs_endpoint))
+        @sqs ||= Shoryuken::AwsConfig.sqs
       end
 
       def topics(name)
@@ -26,16 +26,6 @@ module Shoryuken
 
       attr_accessor :account_id
       attr_writer :sns, :sqs, :sqs_resource, :sns_arn
-
-      private
-
-      def aws_client_options(service_endpoint_key)
-        environment_endpoint = ENV["AWS_#{service_endpoint_key.to_s.upcase}"]
-        explicit_endpoint = Shoryuken::AwsConfig.options[service_endpoint_key] || environment_endpoint
-        options = {}
-        options[:endpoint] = explicit_endpoint unless explicit_endpoint.to_s.empty?
-        options
-      end
     end
   end
 end


### PR DESCRIPTION
### Summary:

Previously (before the **PR #252**) when we're passing `:aws` config on the `shoryuken.yml` options the `Shoryuken::EnvironmentLoader` class where doing all the initialize and overriding the `Aws.config`. So the **SNS** and **SQS** clients where using that config to initialize the clients, this was a problem for those applications that want/need to have different AWS credentials running different services
### Proposal:

Following @phstc comments on the [pull request](https://github.com/phstc/shoryuken/pull/252#issuecomment-255617953) and taking advantage of the recent changes made by @h3poteto I added the `AwsConfig.sns` and `AwsConfig.sqs` that the `Shoryuken::Client` class will call. And remove the override of `Aws.config` and instead the `credentials` are passed directly to the clients.

Hey @phstc let me know what you think about it, I was unsure about your feelings on instance variables or if you have any other style preference or prefer another approach, please feel free to let me know! all comments are welcome 😃 
