### PR TITLE
Strict priority polling / bug fix

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -106,14 +106,24 @@ module Shoryuken
 
       if @ready.empty?
         logger.debug { 'Pausing fetcher, because all processors are busy' }
-        after(1) { dispatch }
+
+        @dispatch_timer ||= after(1) do
+          @dispatch_timer = nil
+          dispatch
+        end
+
         return
       end
 
       queue = polling_strategy.next_queue
       if queue.nil?
         logger.debug { 'Pausing fetcher, because all queues are paused' }
-        after(1) { dispatch }
+
+        @dispatch_timer ||= after(1) do
+          @dispatch_timer = nil
+          dispatch
+        end
+
         return
       end
 

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -19,6 +19,10 @@ module Shoryuken
       end
 
       alias_method :eql?, :==
+
+      def to_s
+        options.empty? ? name : super
+      end
     end
 
     class WeightedRoundRobin

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -123,5 +123,95 @@ module Shoryuken
         queues.count { |q| q == queue }
       end
     end
+
+    class StrictPriority < BaseStrategy
+
+      def initialize(queues)
+        unparsed_queues = unparse_queues(queues)
+        
+        # Mapping of queues to priority values
+        @queue_priorities = unparsed_queues
+          .to_h
+
+        # Priority ordering of the queues
+        @queue_order = unparsed_queues
+          .sort_by { |queue, priority| -priority }
+          .map(&:first)
+
+        # Pause status of the queues
+        @queue_status = @queue_order
+          .map { |queue| [queue, [true, nil]] }
+          .to_h
+
+        # Most recently used queue
+        @current_queue = nil
+      end
+
+      def next_queue
+        unpause_queues
+        @current_queue = next_active_queue
+        return nil if @current_queue.nil?
+        QueueConfiguration.new(@current_queue, {})
+      end
+
+      def messages_found(queue, messages_found)
+        if messages_found == 0
+          # If no messages are found, we pause a given queue
+          pause(queue) 
+        else
+          # Reset the current queue when messages found to cause priorities to re-run
+          @current_queue = nil
+        end
+      end
+
+      def active_queues
+        @queue_status
+          .select { |_, status| status.first }
+          .map { |queue, _| [queue, @queue_priorities[queue]] }
+      end
+
+      private
+
+      def next_active_queue
+        return nil unless @queue_order.length > 0
+
+        start = @current_queue.nil? ? 0 : @queue_order.index(@current_queue) + 1
+        i = 0
+
+        # Loop through the queue order from the current queue until we find a
+        # queue that is next in line and is not paused
+        while true
+          queue = @queue_order[(start + i) % @queue_order.length]
+          active, delay = @queue_status[queue]
+          
+          i += 1
+          return queue if active
+          return nil if i >= @queue_order.length # Prevents infinite looping
+        end
+      end
+
+      def pause(queue)
+        return unless delay > 0
+        @queue_status[queue] = [false, Time.now + delay]
+        logger.debug "Paused '#{queue}'"
+      end
+ 
+      def unpause_queues
+        # Modifies queue statuses for queues that are now unpaused
+        @queue_status = @queue_status.map do |queue, status|
+          active, delay = status
+
+          if active
+            [queue, [true, nil]]
+          elsif Time.now > delay
+            logger.debug "Unpaused '#{queue}'"
+            @current_queue = nil # Reset the check ordering on un-pause
+            [queue, [true, nil]]
+          else
+            [queue, [false, delay]]
+          end
+        end.to_h
+      end
+    end
   end
 end

--- a/lib/shoryuken/polling.rb
+++ b/lib/shoryuken/polling.rb
@@ -25,9 +25,43 @@ module Shoryuken
       end
     end
 
-    class WeightedRoundRobin
+    class BaseStrategy
       include Util
 
+      def next_queue
+        fail NotImplementedError
+      end
+
+      def messages_found(queue, messages_found)
+        fail NotImplementedError
+      end
+
+      def active_queues
+        fail NotImplementedError
+      end
+
+      def ==(other)
+        case other
+        when Array
+          @queues == other
+        else
+          if other.respond_to?(:active_queues)
+            active_queues == other.active_queues
+          else
+            false
+          end
+        end
+      end
+
+      private
+
+      def delay
+        Shoryuken.options[:delay].to_f
+      end
+    end
+
+    class WeightedRoundRobin < BaseStrategy
+      
       def initialize(queues)
         @initial_queues = queues
         @queues = queues.dup.uniq
@@ -61,24 +95,7 @@ module Shoryuken
         unparse_queues(@queues)
       end
 
-      def ==(other)
-        case other
-        when Array
-          @queues == other
-        else
-          if other.respond_to?(:active_queues)
-            active_queues == other.active_queues
-          else
-            false
-          end
-        end
-      end
-
       private
-
-      def delay
-        Shoryuken.options[:delay].to_f
-      end
 
       def pause(queue)
         return unless @queues.delete(queue)

--- a/spec/shoryuken/polling_spec.rb
+++ b/spec/shoryuken/polling_spec.rb
@@ -98,3 +98,142 @@ describe Shoryuken::Polling::WeightedRoundRobin do
     end
   end
 end
+
+describe Shoryuken::Polling::StrictPriority do
+  let(:queue1) { 'shoryuken' }
+  let(:queue2) { 'uppercut' }
+  let(:queue3) { 'other' }
+  let(:queues) { Array.new }
+  subject { Shoryuken::Polling::StrictPriority.new(queues) }
+
+  describe '#next_queue' do
+    it 'cycles when declared desc' do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+    end
+
+    it 'cycles when declared asc' do
+      # [uppercut,  1]
+      # [shoryuken, 2]
+      queues << queue2
+      queues << queue1
+      queues << queue1
+
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+    end
+
+    it 'returns nil if there are no active queues' do
+      expect(subject.next_queue).to eq(nil)
+    end
+
+    it 'unpauses queues whose pause is expired' do
+      # [shoryuken, 3]
+      # [uppercut,  2]
+      # [other,     1]
+      queues << queue1
+      queues << queue1
+      queues << queue1
+      queues << queue2
+      queues << queue2
+      queues << queue3
+
+      allow(subject).to receive(:delay).and_return(10)
+
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      # pause the second queue, see it loop between 1 and 3
+      subject.messages_found(queue2, 0)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue3)
+      expect(subject.next_queue).to eq(queue1)
+
+      now += 5
+      allow(Time).to receive(:now).and_return(now)
+
+      # pause the first queue, see it repeat 3
+      subject.messages_found(queue1, 0)
+      expect(subject.next_queue).to eq(queue3)
+      expect(subject.next_queue).to eq(queue3)
+
+      # pause the third queue, see it have nothing
+      subject.messages_found(queue3, 0)
+      expect(subject.next_queue).to eq(nil)
+
+      # unpause queue 2
+      now += 6
+      allow(Time).to receive(:now).and_return(now)
+      expect(subject.next_queue).to eq(queue2)
+
+      # unpause queues 1 and 3
+      now += 6
+      allow(Time).to receive(:now).and_return(now)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      expect(subject.next_queue).to eq(queue3)
+    end
+  end
+
+  describe '#messages_found' do
+    it 'pauses a queue if there are no messages found' do
+      # [shoryuken, 2]
+      # [uppercut,  1]
+      queues << queue1
+      queues << queue1
+      queues << queue2
+
+      expect(subject.active_queues).to eq([[queue1, 2], [queue2, 1]])
+      expect(subject).to receive(:pause).with(queue1).and_call_original
+      subject.messages_found(queue1, 0)
+      expect(subject.active_queues).to eq([[queue2, 1]])
+    end
+
+    it 'continues to queue the highest priority queue if messages are found' do
+      # [shoryuken, 3]
+      # [uppercut,  2]
+      # [other,     1]
+      queues << queue1
+      queues << queue1
+      queues << queue1
+      queues << queue2
+      queues << queue2
+      queues << queue3
+
+      expect(subject.next_queue).to eq(queue1)
+      subject.messages_found(queue1, 1)
+      expect(subject.next_queue).to eq(queue1)
+      subject.messages_found(queue1, 1)
+      expect(subject.next_queue).to eq(queue1)
+    end
+
+    it 'resets the priorities if messages are found part way' do
+      # [shoryuken, 3]
+      # [uppercut,  2]
+      # [other,     1]
+      queues << queue1
+      queues << queue1
+      queues << queue1
+      queues << queue2
+      queues << queue2
+      queues << queue3
+
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      subject.messages_found(queue2, 1)
+      expect(subject.next_queue).to eq(queue1)
+      expect(subject.next_queue).to eq(queue2)
+      expect(subject.next_queue).to eq(queue3)
+    end
+  end
+end


### PR DESCRIPTION
TL;DR @mariokostelac's PR #236 restructured Shoryuken to improve performance for our jobs significantly / enabled implementation of our use case, so we forked off his PR and implemented Strict Priority Polling similar to that proposed by @gshutler in #106. We additionally found a bug that was causing a lot of problems with our very short running jobs (< 50 ms per job).

Not entirely sure how to handle the merging of this, as @mariokostelac's work in #236 is yet to be integrated, but we thought it would be good to make people aware of it.


---

To describe our Strict Priority polling implementation; we adapted @gshutler's implementation in #106 to mostly preserve its strict priority properties, but to also introduce the ability for queues to pause themselves using the `delay:` option when they find they have no messages available to process.


---

To describe the bug; we noticed that after 15-30 minutes minutes of running the queueing system, the job processing speed would begin to slow to a crawl, going from 10 jobs a second to less than 1 job a second. This was with a config like this;

```
timeout: 30     # Seconds grace to shutdown
concurrency: 1  # The number of allocated threads to process messages. Default 25
delay: 30       # The delay in seconds to pause a queue when it's empty. Default 0
queues:
  - [queue_1, 1]
```

Reviewing the verbose log output, we saw that the following log lines would slowly increase in frequency until they were begin logged many times a second and would start to generate many megabytes of log files every minute, filled 90% with these two lines, and occasionally with notification of a new job starting or completing. This effect would quickly render the Shoryuken process as ineffective and it eventually completely stop processing work.

```
DEBUG: Ready: 0, Busy: 1, Active Queues: [["queue_1", 1]]
DEBUG: Pausing fetcher, because all processors are busy
```

Our working theory is that when `Shoryuken::Manager#processor_done` calls `Shoryuken::Manager#dispatch` in quick succession, as happens with our very short running jobs, the `after(1)` calls within it schedule `#dispatch` to run again and again. As the terminating case for these recursive calls is for the processor to become available, and more and more of these become queued, it becomes less and less likely that they will be cleaned up, until eventually they grow to a number that completely chokes the Shoryuken process.

Our fixes is to change `after(1) { dispatch }` to 

```
@dispatch_timer ||= after(1) do
  @dispatch_timer = nil
  dispatch
end
```

What this does is effectively ensure that only one `#dispatch` will be queued into the future at any one time. Our testing has observed that after this change, this problem does not reoccur.
