### PR TITLE
Add deprecation warning in initialize_aws

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -49,7 +49,11 @@ module Shoryuken
       YAML.load(ERB.new(IO.read(path)).result).deep_symbolize_keys
     end
 
+    # DEPRECATED: Please use configure_server and configure_client in
+    # https://github.com/phstc/shoryuken/blob/a81637d577b36c5cf245882733ea91a335b6602f/lib/shoryuken.rb#L82
+    # Please delete this method afert next release (v2.0.12 or later)
     def initialize_aws
+      Shoryuken.logger.warn { "[DEPRECATION] aws in shoryuken.yml is deprecated. Please use configure_server and configure_client in your initializer"} unless Shoryuken.options[:aws].nil?
       Shoryuken::AwsConfig.setup(Shoryuken.options[:aws])
     end
 


### PR DESCRIPTION
I add deprecation warning in `EnvironmentLoader#initialize_aws`.

In other times, I added aws configuration in `Shoryuken.configure_server`:  https://github.com/phstc/shoryuken/pull/252
Now, Shoryuken has two methods to configure aws.
The first way is the method described above which is use `Shoryuken.configure_server` in initializer.
The second way is the earlier method which is use `shoryuken.yml`.

I think it is intricate that there are two methods to configure aws.

So, I will remove the earlier method which is use `shoryuken.yml`.
Before remove that, I add deprecation warning in `EnvironmentLoader#initialize_aws`. 