### PR TITLE
Adding FIFO Support

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -67,10 +67,10 @@ module Shoryuken
       options = case
                 when options.is_a?(Array)
                   { entries: options.map.with_index do |m, index|
-                    { id: index.to_s }.merge(m.is_a?(Hash) ? m : { message_body: m }).tap(&method(:add_fifo_attributes))
+                    { id: index.to_s }.merge(m.is_a?(Hash) ? m : { message_body: m }).tap(&method(:add_fifo_attributes!))
                   end }
                 when options.is_a?(Hash)
-                  options[:entries].each(&:add_fifo_attributes!)
+                  options[:entries].each(&method(:add_fifo_attributes!))
                   options
                 end
       validate_messages!(options)
@@ -83,6 +83,8 @@ module Shoryuken
 
       message_hash[:message_group_id] = MESSAGE_GROUP_ID
       message_hash[:message_deduplication_id] = SecureRandom.uuid unless has_content_deduplication?
+
+      message_hash
     end
 
     def sanitize_message!(options)

--- a/lib/shoryuken/version.rb
+++ b/lib/shoryuken/version.rb
@@ -1,3 +1,3 @@
 module Shoryuken
-  VERSION = '2.0.11'
+  VERSION = '2.1.0'
 end

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -114,15 +114,15 @@ describe Shoryuken::Queue do
         expect(sqs).to receive(:send_message_batch) do |arg|
           expect(arg).to include(:entries)
           first_entry = arg[:entries].first
-          expect(first_entry).to include({id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage'})
+          expect(first_entry).to include({ id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage' })
           expect(first_entry[:message_deduplication_id]).to be_a String
         end
       }
       it 'sends with message_group_id and message_deduplication_id when an array is sent' do
-        subject.send_messages([{message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+        subject.send_messages([{ message_body: 'msg1', message_attributes: { attr: 'attr1' } }])
       end
       it 'sends with message_group_id and message_deduplication_id  when a hash is sent' do
-        subject.send_messages(entries: [{id: '0', message_body: 'msg1'}])
+        subject.send_messages(entries: [{ id: '0', message_body: 'msg1' }])
       end
     end
 
@@ -135,20 +135,20 @@ describe Shoryuken::Queue do
         expect(sqs).to receive(:send_message_batch) do |arg|
           expect(arg).to include(:entries)
           first_entry = arg[:entries].first
-          expect(first_entry).to match({id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage', message_attributes: {attr: 'attr1'}})
+          expect(first_entry).to match({ id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage', message_attributes: { attr: 'attr1' } })
         end
       }
       it 'sends with message_group_id when argument is an array' do
-        subject.send_messages([{message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+        subject.send_messages([{ message_body: 'msg1', message_attributes: { attr: 'attr1' } }])
       end
       it 'sends with message_group_id when a hash is sent' do
-        subject.send_messages(entries: [{id: '0', message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+        subject.send_messages(entries: [{ id: '0', message_body: 'msg1', message_attributes: { attr: 'attr1' } }])
       end
     end
 
 
     it 'accepts an array of string' do
-      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{id: '0', message_body: 'msg1'}, {id: '1', message_body: 'msg2'}]))
+      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1' }, { id: '1', message_body: 'msg2' }]))
 
       subject.send_messages(%w(msg1 msg2))
     end
@@ -172,12 +172,12 @@ describe Shoryuken::Queue do
     before {
       # Required as Aws::SQS::Client.get_queue_url returns 'String' when responses are stubbed.
       allow(subject).to receive(:url).and_return(queue_url)
-      allow(sqs).to receive(:get_queue_attributes).with({queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication']}).and_return(attribute_response)
+      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication', 'VisibilityTimeout'] }).and_return(attribute_response)
 
     }
     context 'when queue is FIFO' do
       before {
-        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true'})
+        allow(attribute_response).to receive(:attributes).and_return({ 'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true' })
       }
       it 'Returns True' do
         expect(subject.is_fifo?).to eq true
@@ -185,7 +185,7 @@ describe Shoryuken::Queue do
     end
     context 'when queue is not FIFO' do
       before {
-        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'false', 'ContentBasedDeduplication' => 'false'})
+        allow(attribute_response).to receive(:attributes).and_return({ 'FifoQueue' => 'false', 'ContentBasedDeduplication' => 'false' })
       }
       it 'Returns False' do
         expect(subject.is_fifo?).to eq false
@@ -195,12 +195,12 @@ describe Shoryuken::Queue do
 
   describe '#has_content_deduplication?' do
     before {
-      allow(sqs).to receive(:get_queue_attributes).with({queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication']}).and_return(attribute_response)
+      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication', 'VisibilityTimeout'] }).and_return(attribute_response)
 
     }
     context 'when queue has content deduplicaiton' do
       before {
-        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true'})
+        allow(attribute_response).to receive(:attributes).and_return({ 'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true' })
       }
       it 'Returns True' do
         expect(subject.has_content_deduplication?).to eq true
@@ -208,7 +208,7 @@ describe Shoryuken::Queue do
     end
     context 'when queue does not have content deduplication' do
       before {
-        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'false'})
+        allow(attribute_response).to receive(:attributes).and_return({ 'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'false' })
       }
       it 'Returns False' do
         expect(subject.has_content_deduplication?).to eq false

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -2,13 +2,22 @@ require 'spec_helper'
 
 describe Shoryuken::Queue do
   let(:credentials) { Aws::Credentials.new('access_key_id', 'secret_access_key') }
-  let(:sqs)         { Aws::SQS::Client.new(stub_responses: true, credentials: credentials) }
-  let(:queue_name)  { 'shoryuken' }
-  let(:queue_url)   { 'https://eu-west-1.amazonaws.com:6059/123456789012/shoryuken' }
+  let(:sqs) { Aws::SQS::Client.new(stub_responses: true, credentials: credentials) }
+  let(:queue_name) { 'shoryuken' }
+  let(:queue_url) { 'https://eu-west-1.amazonaws.com:6059/123456789012/shoryuken' }
+  let(:attribute_response) { double 'Aws::SQS::Types::GetQueueAttributesResponse' }
 
   subject { described_class.new(sqs, queue_name) }
+  before {
+    # Required as Aws::SQS::Client.get_queue_url returns 'String' when responses are stubbed,
+    # which is not accepted by Aws::SQS::Client.get_queue_attributes for :queue_name parameter.
+    allow(subject).to receive(:url).and_return(queue_url)
+  }
 
   describe '#send_message' do
+    before {
+      allow(subject).to receive(:is_fifo?).and_return(false)
+    }
     it 'accepts SQS request parameters' do
       # https://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#send_message-instance_method
       expect(sqs).to receive(:send_message).with(hash_including(message_body: 'msg1'))
@@ -71,31 +80,75 @@ describe Shoryuken::Queue do
   end
 
   describe '#send_messages' do
+    before {
+      allow(subject).to receive(:is_fifo?).and_return(false)
+    }
     it 'accepts SQS request parameters' do
       # https://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#send_message_batch-instance_method
-      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1'}, { id: '1', message_body: 'msg2' }]))
+      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{id: '0', message_body: 'msg1'}, {id: '1', message_body: 'msg2'}]))
 
-      subject.send_messages(entries: [{ id: '0', message_body: 'msg1'}, { id: '1', message_body: 'msg2' }])
+      subject.send_messages(entries: [{id: '0', message_body: 'msg1'}, {id: '1', message_body: 'msg2'}])
     end
 
     it 'accepts an array of messages' do
-      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1', delay_seconds: 1, message_attributes: { attr: 'attr1' } }, { id: '1', message_body: 'msg2', delay_seconds: 1, message_attributes: { attr: 'attr2' } }]))
+      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{id: '0', message_body: 'msg1', delay_seconds: 1, message_attributes: {attr: 'attr1'}}, {id: '1', message_body: 'msg2', delay_seconds: 1, message_attributes: {attr: 'attr2'}}]))
 
       subject.send_messages([
-        {
-          message_body: 'msg1',
-          delay_seconds: 1,
-          message_attributes: { attr: 'attr1' }
-        }, {
-          message_body: 'msg2',
-          delay_seconds: 1,
-          message_attributes: { attr: 'attr2' }
-        }
-      ])
+                                {
+                                    message_body:       'msg1',
+                                    delay_seconds:      1,
+                                    message_attributes: {attr: 'attr1'}
+                                }, {
+                                    message_body:       'msg2',
+                                    delay_seconds:      1,
+                                    message_attributes: {attr: 'attr2'}
+                                }
+                            ])
     end
 
+    context 'when FIFO is configured without content deduplication' do
+      before {
+        # Arrange
+        allow(subject).to receive(:is_fifo?).and_return(true)
+        # Pre-Assert
+        expect(sqs).to receive(:send_message_batch) do |arg|
+          expect(arg).to include(:entries)
+          first_entry = arg[:entries].first
+          expect(first_entry).to include({id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage'})
+          expect(first_entry[:message_deduplication_id]).to be_a String
+        end
+      }
+      it 'sends with message_group_id and message_deduplication_id when an array is sent' do
+        subject.send_messages([{message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+      end
+      it 'sends with message_group_id and message_deduplication_id  when a hash is sent' do
+        subject.send_messages(entries: [{id: '0', message_body: 'msg1'}])
+      end
+    end
+
+    context 'when FIFO is configured with content deduplication' do
+      before {
+        # Arrange
+        allow(subject).to receive(:is_fifo?).and_return(true)
+        allow(subject).to receive(:has_content_deduplication?).and_return(true)
+        # Pre-Assert
+        expect(sqs).to receive(:send_message_batch) do |arg|
+          expect(arg).to include(:entries)
+          first_entry = arg[:entries].first
+          expect(first_entry).to match({id: '0', message_body: 'msg1', message_group_id: 'ShoryukenMessage', message_attributes: {attr: 'attr1'}})
+        end
+      }
+      it 'sends with message_group_id when argument is an array' do
+        subject.send_messages([{message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+      end
+      it 'sends with message_group_id when a hash is sent' do
+        subject.send_messages(entries: [{id: '0', message_body: 'msg1', message_attributes: {attr: 'attr1'}}])
+      end
+    end
+
+
     it 'accepts an array of string' do
-      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{ id: '0', message_body: 'msg1'}, { id: '1', message_body: 'msg2' }]))
+      expect(sqs).to receive(:send_message_batch).with(hash_including(entries: [{id: '0', message_body: 'msg1'}, {id: '1', message_body: 'msg2'}]))
 
       subject.send_messages(%w(msg1 msg2))
     end
@@ -111,6 +164,54 @@ describe Shoryuken::Queue do
         expect {
           subject.send_messages(entries: [message_body: 1])
         }.to raise_error(ArgumentError, 'The message body must be a String and you passed a Fixnum')
+      end
+    end
+  end
+
+  describe '#is_fifo?' do
+    before {
+      # Required as Aws::SQS::Client.get_queue_url returns 'String' when responses are stubbed.
+      allow(subject).to receive(:url).and_return(queue_url)
+      allow(sqs).to receive(:get_queue_attributes).with({queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication']}).and_return(attribute_response)
+
+    }
+    context 'when queue is FIFO' do
+      before {
+        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true'})
+      }
+      it 'Returns True' do
+        expect(subject.is_fifo?).to eq true
+      end
+    end
+    context 'when queue is not FIFO' do
+      before {
+        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'false', 'ContentBasedDeduplication' => 'false'})
+      }
+      it 'Returns False' do
+        expect(subject.is_fifo?).to eq false
+      end
+    end
+  end
+
+  describe '#has_content_deduplication?' do
+    before {
+      allow(sqs).to receive(:get_queue_attributes).with({queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication']}).and_return(attribute_response)
+
+    }
+    context 'when queue has content deduplicaiton' do
+      before {
+        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'true'})
+      }
+      it 'Returns True' do
+        expect(subject.has_content_deduplication?).to eq true
+      end
+    end
+    context 'when queue does not have content deduplication' do
+      before {
+        allow(attribute_response).to receive(:attributes).and_return({'FifoQueue' => 'true', 'ContentBasedDeduplication' => 'false'})
+      }
+      it 'Returns False' do
+        expect(subject.has_content_deduplication?).to eq false
       end
     end
   end

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -172,7 +172,7 @@ describe Shoryuken::Queue do
     before {
       # Required as Aws::SQS::Client.get_queue_url returns 'String' when responses are stubbed.
       allow(subject).to receive(:url).and_return(queue_url)
-      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication', 'VisibilityTimeout'] }).and_return(attribute_response)
+      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['All'] }).and_return(attribute_response)
 
     }
     context 'when queue is FIFO' do
@@ -195,7 +195,7 @@ describe Shoryuken::Queue do
 
   describe '#has_content_deduplication?' do
     before {
-      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['FifoQueue', 'ContentBasedDeduplication', 'VisibilityTimeout'] }).and_return(attribute_response)
+      allow(sqs).to receive(:get_queue_attributes).with({ queue_url: queue_url, attribute_names: ['All'] }).and_return(attribute_response)
 
     }
     context 'when queue has content deduplicaiton' do


### PR DESCRIPTION
Fixes #272 

Adds FIFO queue type support to Shoryuken.

Changes:

* `Shoryuken::Queue` will now check if the queue is a FIFO queue or not. 
* If it is, messages will have a `MessageGroupId` attached. 
* If the queue is FIFO and does not have content based deduplication enabled, a UUID is assigned as the `MessageDeduplicationId`.
* If the queue is FIFO and the consumer submits a message with `DelaySeconds`, an error will be raised as the SDK would've raised an error any way.