### PR TITLE
Fix aws deprecation warning message

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -53,7 +53,9 @@ module Shoryuken
     # https://github.com/phstc/shoryuken/blob/a81637d577b36c5cf245882733ea91a335b6602f/lib/shoryuken.rb#L82
     # Please delete this method afert next release (v2.0.12 or later)
     def initialize_aws
-      Shoryuken.logger.warn { "[DEPRECATION] aws in shoryuken.yml is deprecated. Please use configure_server and configure_client in your initializer"} unless Shoryuken.options[:aws].nil?
+      unless Shoryuken.options[:aws].to_h.empty?
+        Shoryuken.logger.warn { '[DEPRECATION] aws in shoryuken.yml is deprecated. Please use configure_server and configure_client in your initializer' }
+      end
       Shoryuken::AwsConfig.setup(Shoryuken.options[:aws])
     end
 


### PR DESCRIPTION
Actualy `aws` is always set here https://github.com/phstc/shoryuken/blob/master/lib/shoryuken.rb#L29
so it's never nil, consequently always showing the warning message no
matter if `aws` is set or not