### PR TITLE
Add example endless workers

### DIFF
--- a/test_workers/endless_interruptive_worker.rb
+++ b/test_workers/endless_interruptive_worker.rb
@@ -1,0 +1,41 @@
+class EndlessInterruptiveWorker
+  include Shoryuken::Worker
+
+  # Usage:
+  # QUEUE="super-q"
+  # MAX_EXECUTION_TIME=2000 QUEUE=$QUEUE \
+  # bundle exec ./bin/shoryuken -r ./examples/endless_uninterruptive_worker.rb -q $QUEUE -c 8
+
+  class << self
+    def queue
+      ENV['QUEUE'] || 'default'
+    end
+
+    def max_execution_time
+      ENV["MAX_EXECUTION_TIME"] ? ENV["MAX_EXECUTION_TIME"].to_i : 100
+    end
+
+    def rng
+      @rng ||= Random.new
+    end
+
+    # returns a random number between 0 and 100
+    def random_number(hi = 1000)
+      (rng.rand * hi).to_i
+    end
+  end
+
+  def perform(sqs_msg, body)
+    Shoryuken.logger.info("Received message: '#{body}'")
+
+    execution_ms = self.class.random_number(self.class.max_execution_time)
+    Shoryuken.logger.info("Going to sleep for #{execution_ms}ms")
+
+    new_body = "#{execution_ms}-" + body.to_s
+    sleep(execution_ms.to_f / 1000)
+
+    self.class.perform_async(new_body.slice(0, 512))
+  end
+
+  shoryuken_options queue: queue, auto_delete: true
+end

--- a/test_workers/endless_uninterruptive_worker.rb
+++ b/test_workers/endless_uninterruptive_worker.rb
@@ -1,0 +1,44 @@
+class EndlessUninterruptiveWorker
+  include Shoryuken::Worker
+
+  # Usage:
+  # QUEUE="super-q"
+  # MAX_EXECUTION_TIME=2000 QUEUE=$QUEUE \
+  # bundle exec ./bin/shoryuken -r ./examples/endless_interruptive_worker.rb -q $QUEUE -c 8
+
+  class << self
+    def queue
+      ENV['QUEUE'] || 'default'
+    end
+
+    def max_execution_time
+      ENV["MAX_EXECUTION_TIME"] ? ENV["MAX_EXECUTION_TIME"].to_i : 100
+    end
+
+    def rng
+      @rng ||= Random.new
+    end
+
+    # returns a random number between 0 and 100
+    def random_number(hi = 1000)
+      (rng.rand * hi).to_i
+    end
+  end
+
+  def perform(sqs_msg, body)
+    Shoryuken.logger.info("Received message: '#{body}'")
+
+    execution_ms = self.class.random_number(self.class.max_execution_time)
+    Shoryuken.logger.info("Going to burn metal for #{execution_ms}ms")
+    end_time = Time.now + execution_ms.to_f / 1000
+    while Time.now < end_time do
+      # burn metal
+    end
+
+    new_body = "#{execution_ms}-" + body.to_s
+
+    self.class.perform_async(new_body.slice(0, 512))
+  end
+
+  shoryuken_options queue: queue, auto_delete: true
+end


### PR DESCRIPTION
Very often I need some worker to perform basic E2E test. This two workers should represent a worker that's doing IO (sleep) and workers that are CPU intensive (burning metal).
This should help us to:
1) be confident that at least basic e2e flow works when we release a new version
2) write integration tests if we want them (I'd say we do :))
3) do harness testing by providing different environment variables and running shoryuken for long time.
4) help iterating on issues like https://github.com/phstc/shoryuken/pull/287 quite fast