### PR TITLE
Log info message when processor dies gracefully

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -77,7 +77,11 @@ module Shoryuken
 
     def processor_died(processor, reason)
       watchdog("Manager#processor_died died") do
-        logger.error { "Process died, reason: #{reason}" }
+        if reason
+          logger.error { "Process died, reason: #{reason}" }
+        else
+          logger.info { "Process stopped by user" }
+        end
 
         @threads.delete(processor.object_id)
         @busy.delete processor


### PR DESCRIPTION
When processor dies by our hand, it just throws empty error message `Process died, reason:`.
It looks pretty ugly and is misleading for people who use logs for alarming on error thresholds.

New behaviour:
**graceful shutdown**:
```
2016-12-13T20:19:08Z 95485 TID-ox7x14xyg INFO: Got INT signal
2016-12-13T20:19:08Z 95485 TID-ox7x14xyg INFO: Received INT, will shutdown down
2016-12-13T20:19:08Z 95485 TID-ox7wze1yk INFO: Shutting down 5 quiet workers
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Waiting for 3 busy workers
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Pausing up to 8 seconds to allow workers to finish...
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Process stopped by user
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Process stopped by user
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Process stopped by user
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Process stopped by user
2016-12-13T20:19:10Z 95485 TID-ox7wze1yk INFO: Process stopped by user
```

**forceful shutdown**:
```
2016-12-13T20:17:27Z 95252 TID-ovziv8bzc INFO: Process killed by user
2016-12-13T20:17:27Z 95252 TID-ovziv8bzc INFO: Process killed by user
2016-12-13T20:17:35Z 95252 TID-ovziv8bzc INFO: Hard shutting down 3 busy workers
2016-12-13T20:17:36Z 95252 TID-ovziv8bzc ERROR: Process died, reason: Shoryuken::Shutdown
```

_It is possible that process killed does not get a chance to write the message to the error stream!_