### PR TITLE
Fix memory leak caused by async tracking busy threads

### DIFF
--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -12,17 +12,18 @@ module Shoryuken
     attr_accessor :proxy_id
 
     def process(queue, sqs_msg)
-      @manager.async.real_thread(proxy_id, Thread.current)
-
       worker = Shoryuken.worker_registry.fetch_worker(queue, sqs_msg)
+      body = get_body(worker.class, sqs_msg)
 
-        body = get_body(worker.class, sqs_msg)
+      worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
+        worker.perform(sqs_msg, body)
+      end
 
-        worker.class.server_middleware.invoke(worker, queue, sqs_msg, body) do
-          worker.perform(sqs_msg, body)
-        end
+      @manager.async.processor_done(queue, current_actor)
+    end
 
-        @manager.async.processor_done(queue, current_actor)
+    def running_thread
+      Thread.current
     end
 
     private


### PR DESCRIPTION
Some `printf` debugging foo and reading the code helped to figure out that we were sporadically leaking `Thread` objects when processors died with an error.
https://github.com/phstc/shoryuken/blob/e83a68bf9d460fdd368a38208032074cde085ca2/lib/shoryuken/processor.rb#L15 calls `real_thread` (which pairs Thread and Processor in manager's namespace) asynchronously and it sometimes executes before `processor_died` is executed.

I've set up logs for every addition/removal of `Manager.threads` elements and state after the action. Worker I've used failed randomly, approx 33% of times.

Logs:
```
A: ADD 70141427912260 <-- worker starts
A: KEYS [70141427912260]
A: DONE 70141427912260 <-- worker done
A: DELETE 70141427912260 <-- thread deletion command
A: KEYS [] <-- thread deleted
A: ADD 70141427912260
A: KEYS [70141427912260]
A: DONE 70141427912260
A: DELETE 70141427912260
A: KEYS [] <-- threads empty
A: DIED 70141427912260 <-- worker died
A: DELETE 70141427912260 <-- delete Thread! but hey, it's not even added
A: DELETE 70141427912260 FAIL!
A: KEYS []
A: ADD 70141427912260 <-- oh ok, we're adding it here?! it will stay in forever
A: KEYS [70141427912260]
A: ADD 70141422012480
A: KEYS [70141427912260, 70141422012480]
```

Fixing https://github.com/phstc/shoryuken/issues/88.

One +1 for simplifying the core and getting rid of asynchronous stuff where it's not needed. We should be more deliberate in defining thing as actors and establishing async communication between them.