### PR TITLE
Ignore USR2 signal

### DIFF
--- a/lib/shoryuken/cli.rb
+++ b/lib/shoryuken/cli.rb
@@ -205,6 +205,8 @@ module Shoryuken
         queues = launcher.manager.instance_variable_get(:@queues)
 
         logger.info { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{unparse_queues(queues)}" }
+      when 'USR2'
+        logger.warn { "Received #{sig}, will do nothing. To execute soft shutdown, please send USR1" }
       else
         logger.info { "Received #{sig}, will shutdown down" }
 


### PR DESCRIPTION
# What will be changed by this PR?
This PR modify signal handling to ignore `USR2`. 

```
2016-12-30T02:00:18Z 33879 TID-oxpjqlcdc INFO: Starting
2016-12-30T02:00:46Z 33879 TID-oxpjbckjw INFO: Got USR2 signal
2016-12-30T02:00:46Z 33879 TID-oxpjbckjw WARN: Received USR2, will do nothing. To execute soft shutdown, please send USR1
```

# What this is for?
When we send `USR2` to shoryuken process, shoryuken execute hard shutdown.
But I think this is implicit and dangerous specification. Other popular daemon programs, e.g. `nginx`, `sidekiq` and `unicorn`, do not execute shutdown by sending `USR2`. So I think it is not common usage of `USR2` to execute hard shutdown.

Perhaps USR 2 was considering other uses ( e.g. reopening log like `sidekiq`).  But for now, no implementation for USR2 exists. So I think that it is safe to keep do nothing.