### PR TITLE
Require Celluloid 17

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dotenv'
 
   spec.add_dependency 'aws-sdk-core', '~> 2'
-  spec.add_dependency 'celluloid', '~> 0.16'
+  spec.add_dependency 'celluloid', '~> 0.17'
 end


### PR DESCRIPTION
https://github.com/phstc/shoryuken/blob/master/lib/shoryuken/cli.rb#L72 will fail for celluloid 0.16 as `celluloid/current` does not exist until 0.17