### PR TITLE
Fix initializing sqs client

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -95,7 +95,7 @@ module Shoryuken
     end
 
     def sqs_client=(sqs_client)
-      @@sqs_client
+      @@sqs_client = sqs_client
     end
 
     def sqs_client_receive_message_opts
@@ -103,7 +103,7 @@ module Shoryuken
     end
 
     def sqs_client_receive_message_opts=(sqs_client_receive_message_opts)
-      @@sqs_client_receive_message_opts
+      @@sqs_client_receive_message_opts = sqs_client_receive_message_opts
     end
 
     def options


### PR DESCRIPTION
I try to set custom sqs client in initializer, like this:

```ruby
Shoryuken.configure_server do |config|
  config.sqs_client = Aws::SQS::Client.new(
    endpoint: ENV["SQS_ENDPOINT"],
    secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
    access_key_id: ENV["AWS_ACCESS_KEY_ID"],
    region: ENV["AWS_REGION"]
  )
end
```

But, `Shoryuken.sqs_client` was not my custom sqs client.

The class variable `@@sqs_client` is not assigned in `Shoryuken.sqs_client=(sqs_client)`.