### PR TITLE
Revert shoryuken parameter name to 'config' from 'config_file'

### DIFF
--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -21,7 +21,7 @@ module Shoryuken
       method_option :daemon,      aliases: '-d', type: :boolean, desc: 'Daemonize process'
       method_option :queues,      aliases: '-q', type: :array,   desc: 'Queues to process with optional weights'
       method_option :require,     aliases: '-r', type: :string,  desc: 'Dir or path of the workers'
-      method_option :config_file, aliases: '-C', type: :string,  desc: 'Path to config file'
+      method_option :config,      aliases: '-C', type: :string,  desc: 'Path to config file'
       method_option :rails,       aliases: '-R', type: :boolean, desc: 'Load Rails'
       method_option :logfile,     aliases: '-L', type: :string,  desc: 'Path to logfile'
       method_option :pidfile,     aliases: '-P', type: :string,  desc: 'Path to pidfile'

--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -22,12 +22,18 @@ module Shoryuken
       method_option :queues,      aliases: '-q', type: :array,   desc: 'Queues to process with optional weights'
       method_option :require,     aliases: '-r', type: :string,  desc: 'Dir or path of the workers'
       method_option :config,      aliases: '-C', type: :string,  desc: 'Path to config file'
+      method_option :config_file,                type: :string,  desc: 'Path to config file (backwards compatibility)'
       method_option :rails,       aliases: '-R', type: :boolean, desc: 'Load Rails'
       method_option :logfile,     aliases: '-L', type: :string,  desc: 'Path to logfile'
       method_option :pidfile,     aliases: '-P', type: :string,  desc: 'Path to pidfile'
       method_option :verbose,     aliases: '-v', type: :boolean, desc: 'Print more verbose output'
       def start
         opts = options.to_h.symbolize_keys
+
+        if opts[:config_file] && opts[:config]
+          fail_task 'You may only specify either config_file or config, not both'
+        end
+        opts[:config_file] = opts.delete(:config) if opts[:config] && !opts[:config_file]
 
         # Keep compatibility with old CLI queue format
         opts[:queues] = options[:queues].map { |q| q.split(',') } if options[:queues]


### PR DESCRIPTION
This [commit](432ca4f0fd03adc2efe4e9aee8135dea35f50d3f) changed the parameter name to the shoryuken script from `config` to `config_file`. Among others things, like scripts that manage the starting/stopping of the process, this change breaks the capistrano-shoryuken gem (See https://github.com/joekhoobyar/capistrano-shoryuken/blob/master/lib/capistrano/tasks/shoryuken.cap#L8)

This change reverts the name of the parameter to the original value.
