### PR TITLE
Introduce dispatch event

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -35,6 +35,7 @@ module Shoryuken
     timeout: 8,
     lifecycle_events: {
       startup: [],
+      dispatch: [],
       quiet: [],
       shutdown: []
     },

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -73,6 +73,8 @@ module Shoryuken
           return
         end
 
+        fire_event(:dispatch)
+
         logger.debug { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{@polling_strategy.active_queues}" }
 
         batched_queue?(queue) ? dispatch_batch(queue) : dispatch_single_messages(queue)

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -55,6 +55,13 @@ RSpec.describe Shoryuken::Manager do
     end
   end
 
+  describe '#dispatch_now' do
+    it 'fires a dispatch event' do
+      expect(subject).to receive(:fire_event).with(:dispatch).once
+      subject.send(:dispatch_now)
+    end
+  end
+
   describe '#dispatch_batch' do
     it 'assings batch as a single message' do
       q = polling_strategy.next_queue


### PR DESCRIPTION
This PR introduces a `dispatch` event which fires whenever the dispatcher loop gets called. The possible use case I'm looking at is to monitor uptime and responsiveness of Shoryuken processes by having a callback to ping an instrumentation endpoint.