### PR TITLE
Error logging to allow knowledge of what the failure was before retrying

### DIFF
--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -13,8 +13,6 @@ module Shoryuken
           started_at = Time.now
           yield
         rescue => ex
-          logger.info { "Message #{sqs_msg.message_id} will attempt retry due to error: #{ex.message}" }
-
           retry_intervals = worker.class.get_shoryuken_options['retry_intervals']
 
           if retry_intervals.nil? || !handle_failure(sqs_msg, started_at, retry_intervals)
@@ -23,8 +21,9 @@ module Shoryuken
             raise
           end
 
+          logger.warn { "Message #{sqs_msg.message_id} will attempt retry due to error: #{ex.message}" }
           # since we didn't raise, lets log the backtrace for debugging purposes.
-          logger.debug { ex.backtrace * "\n  " }
+          logger.debug ex.backtrace.join("\n") unless ex.backtrace.nil?
         end
 
         private


### PR DESCRIPTION
In the event of relatively long timeouts between retries of message processing, it would be useful to have preemptive knowledge of such errors.  This will allow any external dependency failures to be known about and remedied before the next retry.