### PR TITLE
Load rails before loading the config file

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -18,13 +18,13 @@ module Shoryuken
     end
 
     def setup_options
+      load_rails if options[:rails]
       initialize_options
       initialize_logger
       merge_cli_defined_queues
     end
 
     def load
-      load_rails if options[:rails]
       prefix_active_job_queue_names
       parse_queues
       require_workers


### PR DESCRIPTION
I believe that the relocation of where rails is loaded introduced in PR [#261](https://github.com/phstc/shoryuken/pull/261) breaks some shoryuken config files. In our case - we are using modules defined in our Rails project to dynamically generate queue names in the configuration. This used to work as far as shoryuken version 2.0.11.

The change is small - really just moving the rails load before config file load, like it used to be.

example config file:
```
delay: 25
concurrency: 25
queues:
<% MyApplication::ApplicationConfig.shoryuken_queues.each_value do |q_cfg| %>
  - [ <%= q_cfg[:q_name] %>, <%= q_cfg[:q_weight] %> ]
<% end %>
```