### PR TITLE
Add new config option to force the fetcher to raise errors

### DIFF
--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -32,8 +32,8 @@ module Shoryuken
 
       begin
         Shoryuken::Client.queues(queue.name).receive_messages(options)
-      rescue => exception
-        raise exception if options[:raise_errors]
+      rescue => ex
+        raise ex if options[:raise_errors]
 
         logger.error { "Error fetching message: #{ex}" }
         logger.error { ex.backtrace.first }

--- a/spec/shoryuken/fetcher_spec.rb
+++ b/spec/shoryuken/fetcher_spec.rb
@@ -3,7 +3,7 @@ require 'shoryuken/manager'
 require 'shoryuken/fetcher'
 
 describe Shoryuken::Fetcher do
-  let(:queue)      { instance_double('Shoryuken::Queue') }
+  let(:queue)      { instance_double('Shoryuken::Queue', receive_messages: []) }
   let(:queue_name) { 'default' }
   let(:queue_config) { Shoryuken::Polling::QueueConfiguration.new(queue_name, {}) }
 
@@ -18,20 +18,57 @@ describe Shoryuken::Fetcher do
   subject { described_class.new }
 
   describe '#fetch' do
+    before do
+      allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
+    end
+
     it 'calls Shoryuken::Client to receive messages' do
       expect(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
       expect(queue).to receive(:receive_messages).
-        with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All']).
-        and_return([])
+        with(max_number_of_messages: 1, attribute_names: ['All'], message_attribute_names: ['All'])
       subject.fetch(queue_config, 1)
     end
 
     it 'maxes messages to receive to 10 (SQS limit)' do
-      allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
       expect(queue).to receive(:receive_messages).
-        with(max_number_of_messages: 10, attribute_names: ['All'], message_attribute_names: ['All']).
-        and_return([])
+        with(max_number_of_messages: 10, attribute_names: ['All'], message_attribute_names: ['All'])
       subject.fetch(queue_config, 20)
+    end
+
+    context 'when an error is raised' do
+      let(:exception) { StandardError.new('Error fetching messages') }
+
+      before do
+        allow(queue).to receive(:receive_messages).and_raise(exception)
+      end
+
+      it 'does not raise the error' do
+        expect do
+          subject.fetch(queue_config, 1)
+        end.not_to raise_error
+      end
+
+      it 'returns an empty set of messages' do
+        return_value = subject.fetch(queue_config, 1)
+        expect(return_value).to eq([])
+      end
+
+      context 'when configured to raise errors' do
+        around(:each) do |example|
+          original_opts = Shoryuken.sqs_client_receive_message_opts
+          Shoryuken.sqs_client_receive_message_opts = original_opts.dup.merge(raise_errors: true)
+
+          example.run
+
+          Shoryuken.sqs_client_receive_message_opts = original_opts
+        end
+
+        it 'raises the error' do
+          expect do
+            subject.fetch(queue_config, 1)
+          end.to raise_error(StandardError, 'Error fetching messages')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Depending on your process monitoring setup it may be preferable to have Shoryuken raise errors it encounters while fetching messages (rather than the default behaviour of silently logging these errors).

The fetcher can now be forced to raise errors using the `Shoryuken.sqs_client_receive_message_opts[:raise_errors]` configuration option. Existing behaviour is preserved when this option is not set.

Possibly this option would be better located in `default_worker_options`, I'm happy either way.

This is an opt-in solution to https://github.com/phstc/shoryuken/issues/369 which will not require a major version change.