### PR TITLE
allow aws sdk v3

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'dotenv'
 
-  spec.add_dependency 'aws-sdk-core', '~> 2'
+  spec.add_dependency 'aws-sdk-core', '> 2'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'thor'
 end


### PR DESCRIPTION
Probably should go and define the specific gems in use once sdk v3 is released.