### PR TITLE
Load Rails if specified `rails: true` in configuration file

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -24,7 +24,7 @@ module Shoryuken
     end
 
     def load
-      load_rails if options[:rails]
+      load_rails if Shoryuken.options[:rails]
       prefix_active_job_queue_names
       parse_queues
       require_workers


### PR DESCRIPTION
Currently, you are able to load Rails environment only if explicitly specified on the command line with `-R`. This behavior occurs because `Shoryuken::EnvironmentLoader` checks the `:rails` flag in the current `options` hash of the class, which contains only the path to the `:config_file`.

With this change, it will be possible to enable the Rails flag in the `shoryuken.yml`.