### PR TITLE
Reduce verbose log

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -31,7 +31,7 @@ module Shoryuken
     def dispatch
       return if stopped?
 
-      if !ready.positive? || (queue = @polling_strategy.next_queue).nil?
+      if ready <= 0 || (queue = @polling_strategy.next_queue).nil?
         return dispatch_later
       end
 

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -37,7 +37,7 @@ module Shoryuken
 
       fire_event(:dispatch)
 
-      logger.info { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{@polling_strategy.active_queues}" }
+      logger.debug { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{@polling_strategy.active_queues}" }
 
       batched_queue?(queue) ? dispatch_batch(queue) : dispatch_single_messages(queue)
 

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -48,8 +48,13 @@ RSpec.describe Shoryuken::Manager do
   end
 
   describe '#dispatch' do
-    xit 'fires a dispatch event' do
+    it 'fires a dispatch event' do
+      # prevent dispatch loop
+      allow(subject).to receive(:stopped?).and_return(false, true)
+
       expect(subject).to receive(:fire_event).with(:dispatch)
+      expect(Shoryuken.logger).to_not receive(:info)
+
       subject.send(:dispatch)
     end
   end


### PR DESCRIPTION
Fix #397

The dispatch log `info` instead of `debug` was mistakenly re-introduced in 3.1.0.