### PR TITLE
Fail fast on bad URL

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -49,22 +49,25 @@ module Shoryuken
 
     private
 
-    def parse_queue_url_params(name_or_url)
-      if name_or_url.start_with?('https://sqs.')
-        *_, account_id, queue_name = URI.parse(name_or_url).path.split('/')
-        {
-          queue_name: queue_name,
-          queue_owner_aws_account_id: account_id
-        }
-      else
-        { queue_name: name_or_url }
-      end
+    def set_by_name(name)
+      self.name = name
+      self.url  = client.get_queue_url(queue_name: name).queue_url
+    end
+
+    def set_by_url(url)
+      self.name = url.split('/').last
+      self.url  = url
     end
 
     def set_name_and_url(name_or_url)
-      queue_url_params = parse_queue_url_params(name_or_url)
-      self.name = queue_url_params[:queue_name]
-      self.url  = client.get_queue_url(queue_url_params)
+      if name_or_url.start_with?('https://sqs.')
+        set_by_url(name_or_url)
+
+        # anticipate the fifo? checker for validating the queue URL
+        return fifo?
+      end
+
+      set_by_name(name_or_url)
     rescue Aws::Errors::NoSuchEndpointError, Aws::SQS::Errors::NonExistentQueue => ex
       raise ex, "The specified queue #{name_or_url} does not exist."
     end

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -49,16 +49,20 @@ module Shoryuken
 
     private
 
+    def parse_queue_url_params(name_or_url)
+      if name_or_url.start_with?('https://sqs.')
+        *_, account_id, queue_name = URI.parse(name_or_url).path.split('/')
+        {
+          queue_name: queue_name,
+          queue_owner_aws_account_id: account_id
+        }
+      else
+        { queue_name: name_or_url }
+      end
+    end
+
     def set_name_and_url(name_or_url)
-      queue_url_params = if name_or_url.start_with?('https://sqs.')
-                           *_, account_id, queue_name = URI.parse(name_or_url).path.split('/')
-                           {
-                             queue_name: queue_name,
-                             queue_owner_aws_account_id: account_id
-                           }
-                         else
-                           { queue_name: name_or_url }
-                         end
+      queue_url_params = parse_queue_url_params(name_or_url)
       self.name = queue_url_params[:queue_name]
       self.url  = client.get_queue_url(queue_url_params)
     rescue Aws::Errors::NoSuchEndpointError, Aws::SQS::Errors::NonExistentQueue => ex

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -51,11 +51,10 @@ module Shoryuken
 
     def set_name_and_url(name_or_url)
       queue_url_params = if name_or_url.start_with?('https://sqs.')
-                           url = URI.parse(name_or_url).path.split('/')
-
+                           *_, account_id, queue_name = URI.parse(name_or_url).path.split('/')
                            {
-                             queue_name: url.last,
-                             queue_owner_aws_account_id: url.second_to_last
+                             queue_name: queue_name,
+                             queue_owner_aws_account_id: account_id
                            }
                          else
                            { queue_name: name_or_url }


### PR DESCRIPTION
Closes #412

`get_queue_url` allows you to optionally specify the account_id of the queue, so this basically programmatically verifies that the queue is correct and verifies that the correct permissions are in place to use the URL in the first place.

http://docs.aws.amazon.com/sdkforruby/api/Aws/SQS/Client.html#get_queue_url