### PR TITLE
Look for polling strategy inside groups config

### DIFF
--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,7 +57,7 @@ module Shoryuken
       end
 
       def polling_strategy(group)
-        option_group = (group == 'default') ? options : options[:groups][group]
+        option_group = group == 'default' ? options : options[:groups][group]
         strategy = option_group.to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
         strategy = "Shoryuken::Polling::#{strategy}".constantize if strategy.is_a?(String)
         strategy

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,10 +57,18 @@ module Shoryuken
       end
 
       def polling_strategy(group)
-        option_group = group == 'default' ? options : options[:groups][group]
-        strategy = option_group.to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
-        strategy = "Shoryuken::Polling::#{strategy}".constantize if strategy.is_a?(String)
-        strategy
+        strategy = (group == 'default' ? options : options[:groups][group]).to_h[:polling_strategy]
+
+        case strategy
+        when 'WeightedRoundRobin', nil # Default case
+          Polling::WeightedRoundRobin
+        when 'StrictPriority'
+          Polling::StrictPriority
+        when Class
+          strategy
+        else
+          raise ArgumentError, "#{strategy} is not a valid polling_strategy"
+        end
       end
 
       def start_callback

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,7 +57,9 @@ module Shoryuken
       end
 
       def polling_strategy(group)
-        options[:groups][group].to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
+        strategy = options[:groups][group].to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
+        strategy = "Shoryuken::Polling::#{strategy}".constantize if strategy.is_a?(String)
+        strategy
       end
 
       def start_callback

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,7 +57,8 @@ module Shoryuken
       end
 
       def polling_strategy(group)
-        strategy = options[:groups][group].to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
+        option_group = (group == 'default') ? options : options[:groups][group]
+        strategy = option_group.to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
         strategy = "Shoryuken::Polling::#{strategy}".constantize if strategy.is_a?(String)
         strategy
       end

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -57,7 +57,7 @@ module Shoryuken
       end
 
       def polling_strategy(group)
-        options[group].to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
+        options[:groups][group].to_h.fetch(:polling_strategy, Polling::WeightedRoundRobin)
       end
 
       def start_callback

--- a/spec/shoryuken/options_spec.rb
+++ b/spec/shoryuken/options_spec.rb
@@ -97,4 +97,84 @@ RSpec.describe Shoryuken::Options do
         "and Shoryuken doesn't support a batchable worker for a queue with multiple workers")
     end
   end
+
+  describe '.polling_strategy' do
+    context 'when not set' do
+      specify do
+        expect(Shoryuken.polling_strategy('default')).to eq Shoryuken::Polling::WeightedRoundRobin
+        expect(Shoryuken.polling_strategy('group1')).to eq Shoryuken::Polling::WeightedRoundRobin
+      end
+    end
+
+    context 'when set to StrictPriority string' do
+      before do
+        Shoryuken.options[:polling_strategy] = 'StrictPriority'
+
+        Shoryuken.options[:groups] = {
+          'group1' => {
+            polling_strategy: 'StrictPriority'
+          }
+        }
+      end
+
+      specify do
+        expect(Shoryuken.polling_strategy('default')).to eq Shoryuken::Polling::StrictPriority
+        expect(Shoryuken.polling_strategy('group1')).to eq Shoryuken::Polling::StrictPriority
+      end
+    end
+
+    context 'when set to WeightedRoundRobin string' do
+      before do
+        Shoryuken.options[:polling_strategy] = 'WeightedRoundRobin'
+
+        Shoryuken.options[:groups] = {
+          'group1' => {
+            polling_strategy: 'WeightedRoundRobin'
+          }
+        }
+      end
+
+      specify do
+        expect(Shoryuken.polling_strategy('default')).to eq Shoryuken::Polling::WeightedRoundRobin
+        expect(Shoryuken.polling_strategy('group1')).to eq Shoryuken::Polling::WeightedRoundRobin
+      end
+    end
+
+    context 'when set to non-existent string' do
+      before do
+        Shoryuken.options[:polling_strategy] = 'NonExistent1'
+
+        Shoryuken.options[:groups] = {
+          'group1' => {
+            polling_strategy: 'NonExistent2'
+          }
+        }
+      end
+
+      specify do
+        expect { Shoryuken.polling_strategy('default') }.to raise_error(ArgumentError)
+        expect { Shoryuken.polling_strategy('group1') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when set to a class' do
+      before do
+        class Foo < Shoryuken::Polling::BaseStrategy; end
+        class Bar < Shoryuken::Polling::BaseStrategy; end
+
+        Shoryuken.options[:polling_strategy] = Foo
+
+        Shoryuken.options[:groups] = {
+          'group1' => {
+            polling_strategy: Bar
+          }
+        }
+      end
+
+      specify do
+        expect(Shoryuken.polling_strategy('default')).to eq Foo
+        expect(Shoryuken.polling_strategy('group1')).to eq Bar
+      end
+    end
+  end
 end


### PR DESCRIPTION
Allows group config to specify polling strategy in the .yml like so;

```
timeout: 1140
delay: 60

groups:
  r:
    concurrency: 1
    polling_strategy: StrictPriority
    queues:
      - x
      - y
      - z
  q:
    concurrency: 1
    polling_strategy: StrictPriority
    queues:
      - a
      - b
      - c
```

or like so

```
timeout: 1140
delay: 60
concurrency: 1
polling_strategy: StrictPriority
queues:
  - x
  - y
  - z
```

Note: this change would be backwards incompatible with the current way of setting strategy described [here](https://github.com/phstc/shoryuken/wiki/Polling-strategies). I have a version that also preserves that behaviour, but it's more complicated.