### PR TITLE
Add argument support to #fire_event

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -37,7 +37,7 @@ module Shoryuken
         return sleep(MIN_DISPATCH_INTERVAL)
       end
 
-      fire_event(:dispatch)
+      fire_event(:dispatch, false, queue_name: queue.name)
 
       logger.debug { "Ready: #{ready}, Busy: #{busy}, Active Queues: #{@polling_strategy.active_queues}" }
 

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -4,13 +4,13 @@ module Shoryuken
       Shoryuken.logger
     end
 
-    def fire_event(event, reverse = false)
+    def fire_event(event, reverse = false, event_options = {})
       logger.debug { "Firing '#{event}' lifecycle event" }
       arr = Shoryuken.options[:lifecycle_events][event]
       arr.reverse! if reverse
       arr.each do |block|
         begin
-          block.call
+          block.call(event_options)
         rescue => ex
           logger.warn(event: event)
           logger.warn "#{ex.class.name}: #{ex.message}"

--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Shoryuken::Manager do
       q = Shoryuken::Polling::QueueConfiguration.new(queue, {})
 
       expect(fetcher).to receive(:fetch).with(q, concurrency).and_return(messages)
-      expect(subject).to receive(:fire_event).with(:dispatch)
+      expect(subject).to receive(:fire_event).with(:dispatch, false, queue_name: q.name)
       expect(Shoryuken::Processor).to receive(:process).with(q, message)
       expect(Shoryuken.logger).to_not receive(:info)
 
@@ -83,7 +83,7 @@ RSpec.describe Shoryuken::Manager do
         q = Shoryuken::Polling::QueueConfiguration.new(queue, {})
 
         expect(fetcher).to receive(:fetch).with(q, described_class::BATCH_LIMIT).and_return(messages)
-        expect(subject).to receive(:fire_event).with(:dispatch)
+        expect(subject).to receive(:fire_event).with(:dispatch, false, queue_name: q.name)
         allow(subject).to receive(:batched_queue?).with(q).and_return(true)
         expect(Shoryuken::Processor).to receive(:process).with(q, messages)
         expect(Shoryuken.logger).to_not receive(:info)

--- a/spec/shoryuken/util_spec.rb
+++ b/spec/shoryuken/util_spec.rb
@@ -26,4 +26,28 @@ describe 'Shoryuken::Util' do
 
     it 'returns ActiveJob worker name'
   end
+
+  describe '#fire_event' do
+    let(:value_holder ) { Object.new }
+    let(:callback_without_options ) { Proc.new { value_holder.value = :without_options } }
+    let(:callback_with_options ) { Proc.new { |options| value_holder.value = [:with_options, options] } }
+
+    after :all do
+      Shoryuken.options[:lifecycle_events].delete( :some_event )
+    end
+
+    it "will trigger callbacks that do not accept arguments" do
+      Shoryuken.options[:lifecycle_events][:some_event] = [callback_without_options]
+
+      expect(value_holder).to receive(:value=).with(:without_options)
+      subject.fire_event(:some_event)
+    end
+
+    it "will trigger callbacks that accept an argument" do
+      Shoryuken.options[:lifecycle_events][:some_event] = [callback_with_options]
+
+      expect( value_holder ).to receive( :value= ).with([:with_options, {my_option: :some_option}])
+      subject.fire_event(:some_event, false, my_option: :some_option)
+    end
+  end
 end


### PR DESCRIPTION
The main feature of this pull request is that it will add the queue name to the `:dispatch` lifecycle event.

I can think of a couple different method signatures for `#fire_event`.  I'm happy to consider other signatures if you have opinions about it.

What I chose:

```ruby
def fire_event(event, options = {} , *event_args)
```

The other way that I considered:

```ruby
def fire_event( event, reverse = false, *event_args )
```