### PR TITLE
Add support for adding a middleware to the front of chain

### DIFF
--- a/lib/shoryuken/middleware/chain.rb
+++ b/lib/shoryuken/middleware/chain.rb
@@ -61,6 +61,10 @@ module Shoryuken
         entries << Entry.new(klass, *args) unless exists?(klass)
       end
 
+      def prepend(klass, *args)
+        entries.insert(0, Entry.new(klass, *args)) unless exists?(klass)
+      end
+
       def insert_before(oldklass, newklass, *args)
         i = entries.index { |entry| entry.klass == newklass }
         new_entry = i.nil? ? Entry.new(newklass, *args) : entries.delete_at(i)

--- a/spec/shoryuken/middleware/chain_spec.rb
+++ b/spec/shoryuken/middleware/chain_spec.rb
@@ -20,6 +20,12 @@ describe Shoryuken::Middleware::Chain do
     expect(CustomMiddleware).to eq subject.entries.last.klass
   end
 
+  it 'can add middleware to the front of chain' do
+    subject.prepend CustomMiddleware, 1, []
+
+    expect(CustomMiddleware).to eq subject.entries.first.klass
+  end
+
   it 'invokes a middleware' do
     recorder = []
     subject.add CustomMiddleware, 'Pablo', recorder


### PR DESCRIPTION
This PR introduces `Chain#prepend` which will insert a middleware to the front of the chain. 