### PR TITLE
shoryuken_options doesn't change arguments

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -61,10 +61,9 @@ module Shoryuken
       end
 
       def stringify_keys(hash) # :nodoc:
-        hash.keys.each do |key|
-          hash[key.to_s] = hash.delete(key)
-        end
-        hash
+        new_hash = {}
+        hash.each { |key, value| new_hash[key.to_s] = value }
+        new_hash
       end
 
       private

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe 'Shoryuken::Worker' do
       expect(NewTestWorker.get_shoryuken_options['queue']).to eq 'production_default'
     end
 
+    it 'not change arguments' do
+      class TestWorker
+        include Shoryuken::Worker
+
+        OPT = { queue: :default }
+
+        shoryuken_options OPT
+      end
+
+      expect(TestWorker::OPT['queue']).to eq(nil)
+      expect(TestWorker::OPT[:queue]).to eq(:default)
+    end
+
     it 'accepts an array as a queue' do
       class WorkerMultipleQueues
         include Shoryuken::Worker


### PR DESCRIPTION
The `shoryuken_option` method break arguments.
So we can't reuse option value.. :(

This change `stringify_keys` method create new hash and return it.