### PR TITLE
Lock aws-sdk

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'dotenv'
 
-  spec.add_dependency 'aws-sdk-core', '> 2'
+  spec.add_dependency 'aws-sdk-core', '~> 2'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'thor'
 end


### PR DESCRIPTION
The awd-sdk-core 3.x is major version up and many breaking changes.
So we should lock 2.x until support 3.x version.