### PR TITLE
Add -t option to CLI

### DIFF
--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -21,6 +21,7 @@ module Shoryuken
       method_option :daemon,      aliases: '-d', type: :boolean, desc: 'Daemonize process'
       method_option :queues,      aliases: '-q', type: :array,   desc: 'Queues to process with optional weights'
       method_option :require,     aliases: '-r', type: :string,  desc: 'Dir or path of the workers'
+      method_option :timeout,     aliases: '-t', type: :numeric, desc: 'Hard shutdown timeout'
       method_option :config,      aliases: '-C', type: :string,  desc: 'Path to config file'
       method_option :config_file,                type: :string,  desc: 'Path to config file (backwards compatibility)'
       method_option :rails,       aliases: '-R', type: :boolean, desc: 'Load Rails'


### PR DESCRIPTION
From the wiki:

https://github.com/phstc/shoryuken/wiki/Signals#term

>Tells Shoryuken to hard shutdown within a timeout. Any processors that do not finish within the timeout are hard terminated and their messages are pushed back to AWS SQS. The timeout defaults to 8 seconds since all Heroku processes must exit within 10 seconds.

The described `-t` option was never actually configured in Thor

> The timeout can be defined through the -t option or in the -C shoryuken.yml config by setting the timeout: N value.