### PR TITLE
Preserves parent worker class options

### DIFF
--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -2,6 +2,7 @@ module Shoryuken
   module Worker
     def self.included(base)
       base.extend(ClassMethods)
+      base.shoryuken_class_attribute :shoryuken_options_hash
     end
 
     module ClassMethods
@@ -22,7 +23,7 @@ module Shoryuken
       end
 
       def shoryuken_options(opts = {})
-        @shoryuken_options = get_shoryuken_options.merge(stringify_keys(opts || {}))
+        self.shoryuken_options_hash = get_shoryuken_options.merge(stringify_keys(opts || {}))
         normalize_worker_queue!
       end
 
@@ -39,7 +40,7 @@ module Shoryuken
       end
 
       def get_shoryuken_options # :nodoc:
-        @shoryuken_options || Shoryuken.default_worker_options
+        shoryuken_options_hash || Shoryuken.default_worker_options
       end
 
       def stringify_keys(hash) # :nodoc:
@@ -48,23 +49,78 @@ module Shoryuken
         new_hash
       end
 
+      def shoryuken_class_attribute(*attrs) # :nodoc:
+        attrs.each do |name|
+          singleton_class.instance_eval do
+            undef_method(name) if method_defined?(name) || private_method_defined?(name)
+          end
+          define_singleton_method(name) { nil }
+
+          ivar = "@#{name}"
+
+          singleton_class.instance_eval do
+            m = "#{name}="
+            undef_method(m) if method_defined?(m) || private_method_defined?(m)
+          end
+
+          define_singleton_method("#{name}=") do |val|
+            singleton_class.class_eval do
+              undef_method(name) if method_defined?(name) || private_method_defined?(name)
+              define_method(name) { val }
+            end
+
+            # singleton? backwards compatibility for ruby < 2.1
+            singleton_klass = respond_to?(:singleton?) ? singleton? : self != ancestors.first
+
+            if singleton_klass
+              class_eval do
+                undef_method(name) if method_defined?(name) || private_method_defined?(name)
+                define_method(name) do
+                  if instance_variable_defined? ivar
+                    instance_variable_get ivar
+                  else
+                    singleton_class.send name
+                  end
+                end
+              end
+            end
+            val
+          end
+
+          # instance reader
+          undef_method(name) if method_defined?(name) || private_method_defined?(name)
+          define_method(name) do
+            if instance_variable_defined?(ivar)
+              instance_variable_get ivar
+            else
+              self.class.public_send name
+            end
+          end
+
+          # instance writer
+          m = "#{name}="
+          undef_method(m) if method_defined?(m) || private_method_defined?(m)
+          attr_writer name
+        end
+      end
+
       private
 
       def normalize_worker_queue!
-        queue = @shoryuken_options['queue']
+        queue = shoryuken_options_hash['queue']
         if queue.respond_to?(:call)
           queue = queue.call
-          @shoryuken_options['queue'] = queue
+          shoryuken_options_hash['queue'] = queue
         end
 
-        case @shoryuken_options['queue']
+        case shoryuken_options_hash['queue']
         when Array
-          @shoryuken_options['queue'].map!(&:to_s)
+          shoryuken_options_hash['queue'].map!(&:to_s)
         when Symbol
-          @shoryuken_options['queue'] = @shoryuken_options['queue'].to_s
+          shoryuken_options_hash['queue'] = shoryuken_options_hash['queue'].to_s
         end
 
-        [@shoryuken_options['queue']].flatten.compact.each(&method(:register_worker))
+        [shoryuken_options_hash['queue']].flatten.compact.each(&method(:register_worker))
       end
 
       def register_worker(queue)

--- a/spec/shoryuken/worker_spec.rb
+++ b/spec/shoryuken/worker_spec.rb
@@ -88,6 +88,23 @@ RSpec.describe Shoryuken::Worker do
       expect(Shoryuken.worker_registry.workers('symbol_queue2')).to eq([WorkerMultipleSymbolQueues])
       expect(Shoryuken.worker_registry.workers('symbol_queue3')).to eq([WorkerMultipleSymbolQueues])
     end
+
+    it 'preserves parent class options' do
+      class ParentWorker
+        include Shoryuken::Worker
+
+        shoryuken_options queue: "myqueue", auto_delete: false
+      end
+
+      class ChildWorker < ParentWorker
+        shoryuken_options auto_delete: true
+      end
+
+      expect(ParentWorker.get_shoryuken_options['queue']).to eq("myqueue")
+      expect(ChildWorker.get_shoryuken_options['queue']).to eq("myqueue")
+      expect(ParentWorker.get_shoryuken_options['auto_delete']).to eq(false)
+      expect(ChildWorker.get_shoryuken_options['auto_delete']).to eq(true)
+    end
   end
 
   describe '.server_middleware' do


### PR DESCRIPTION
Relates to #450

Uses a `shoryuken_class_attribute` implementation that preserves parent
worker class options and allow child classes to override those.

Example:

```ruby
class ParentWorker
  include ShoryukenWorker

  shoryuken_options queue: "myqueue", auto_delete: true
end

class ChildWorker < ParentWorker
  shoryuken_options auto_delete: false
end
```

In this example, the ChildWorker will carry on the parent options, and
override the `auto_delete` configuration.