### PR TITLE
reset Client @@queues on .sqs= call

### DIFF
--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -12,6 +12,10 @@ module Shoryuken
       end
 
       def sqs=(sqs)
+        # Since the @@queues values (Shoryuken::Queue objects) are built referencing @@sqs, if it changes, we need to
+        #   re-build them on subsequent calls to `.queues(name)`.
+        @@queues = {}
+
         @@sqs = sqs
       end
     end

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -12,11 +12,13 @@ module Shoryuken
       end
 
       def sqs=(sqs)
+        @@sqs = sqs
+        
         # Since the @@queues values (Shoryuken::Queue objects) are built referencing @@sqs, if it changes, we need to
         #   re-build them on subsequent calls to `.queues(name)`.
         @@queues = {}
-
-        @@sqs = sqs
+        
+        @@sqs
       end
     end
   end


### PR DESCRIPTION
I have an interesting use-case where I need to use temporary access credentials that are refreshed periodically. In order to get Shoryuken to play nicely with that paradigm, I needed to make this change.