### PR TITLE
Allow Batch Size to be Specified for Requeue

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -152,7 +152,7 @@ module Shoryuken
       end
 
       desc 'requeue QUEUE-NAME PATH', 'Requeues messages from a dump file'
-      method_option :batch_size, aliases: '-n', type: :numeric, default: 10, desc: 'number messages per batch to send'
+      method_option :batch_size, aliases: '-n', type: :numeric, default: 10, desc: 'number of messages per batch to send'
       def requeue(queue_name, path)
         fail_task "Path #{path} not found" unless File.exist?(path)
 


### PR DESCRIPTION
Sometimes batches of 10 messages will be larger than the 256KB per-request limit of batch send so allow this to be specified on the command-line during re-queue.

A better (future) option would be to automatically detect the message size and only send as many messages as will fit in a batch send request.