### PR TITLE
implement TSTP handling

### DIFF
--- a/lib/shoryuken/runner.rb
+++ b/lib/shoryuken/runner.rb
@@ -19,7 +19,7 @@ module Shoryuken
     def run(options)
       self_read, self_write = IO.pipe
 
-      %w(INT TERM USR1 TTIN).each do |sig|
+      %w(INT TERM USR1 TSTP TTIN).each do |sig|
         begin
           trap sig do
             self_write.puts(sig)
@@ -106,6 +106,12 @@ module Shoryuken
       exit 0
     end
 
+    def execute_terminal_stop
+      logger.info { 'Received TSTP, will stop accepting new work' }
+
+      @launcher.stop
+    end
+
     def print_threads_backtrace
       Thread.list.each do |thread|
         logger.info { "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}" }
@@ -123,8 +129,9 @@ module Shoryuken
       case sig
       when 'USR1' then execute_soft_shutdown
       when 'TTIN' then print_threads_backtrace
+      when 'TSTP' then execute_terminal_stop
       when 'TERM', 'INT'
-        logger.info { "Received #{sig}, will shutdown down" }
+        logger.info { "Received #{sig}, will shutdown" }
 
         raise Interrupt
       end


### PR DESCRIPTION
Implements TSTP signal handler: Fixes #479 

TSTP tells Shoryuken to "quiet" as it will be shutting down at some point in the near future. It will stop fetching new jobs but continue working on current jobs. Use TSTP + TERM to guarantee shutdown within a time period. Best practice is to send TSTP at the start of a deploy and TERM at the end of a deploy.

Note you still need to send TERM to actually exit the Shoryuken process.
 
Tests:

I tested against a shoryuken process with no active jobs and it behaved as expected.
I also tested sending some jobs to the shoryuken process and verified active ones were allowed to finish, and new jobs stopped being accepted.

I looked around and didn't see any spec tests for signals.