### PR TITLE
Config by environment

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -45,10 +45,14 @@ module Shoryuken
       fail ArgumentError, "The supplied config file #{path} does not exist" unless File.exist?(path)
 
       if (result = YAML.load(ERB.new(IO.read(path)).result))
-        result.deep_symbolize_keys
+        merge_config_by_environment(result.deep_symbolize_keys, ENV['RAILS_ENV'].to_sym)
       else
         {}
       end
+    end
+
+    def merge_config_by_environment(config, environment)
+      config.merge!(config.delete(environment))
     end
 
     def initialize_logger


### PR DESCRIPTION
Lets you configure shoryuken by environment, just like `config/database.yml`

```yaml
concurrency: 1
queues:
- [queue1, 1]
- [queue2, 2]

staging:
  concurrency: 5
  queues:
  - [staging-queue1, 1]
  - [staging-queue2, 2]

production:
  concurrency: 10
  queues:
  - [production-queue1, 1]
  - [production-queue2, 2]
```