### PR TITLE
Allow supplying an empty list of queues

### DIFF
--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -35,9 +35,9 @@ module Shoryuken
         opts[:config_file] = opts.delete(:config) if opts[:config]
 
         # Keep compatibility with old CLI queue format
-        opts[:queues] = options[:queues].map { |q| q.split(',') } if options[:queues]
+        opts[:queues] = opts[:queues].map { |q| q.split(',') } if opts[:queues]
 
-        fail_task "You should set a logfile if you're going to daemonize" if options[:daemon] && options[:logfile].nil?
+        fail_task "You should set a logfile if you're going to daemonize" if opts[:daemon] && opts[:logfile].nil?
 
         Shoryuken::Runner.instance.run(opts.freeze)
       end

--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -35,7 +35,7 @@ module Shoryuken
         opts[:config_file] = opts.delete(:config) if opts[:config]
 
         # Keep compatibility with old CLI queue format
-        opts[:queues] = opts[:queues].map { |q| q.split(',') } if opts[:queues]
+        opts[:queues] = opts[:queues].reject(&:empty?).map { |q| q.split(',') } if opts[:queues]
 
         fail_task "You should set a logfile if you're going to daemonize" if opts[:daemon] && opts[:logfile].nil?
 


### PR DESCRIPTION
It can be very useful to start a Shoryuken process without any queues.
For instance, this allows us to easily "pause" Shoryuken.

This currently possible using the config file:
```bash
$ touch no_queues.yml
$ bundle exec shoryuken --config no_queues.yml
WARN: No queues supplied
INFO: Starting
```

However, it's impossible using command line arguments:
```bash
$ bundle exec shoryuken --queues=""
NoMethodError: undefined method `start_with?' for nil:NilClass
```

It would be amazing to make the behaviour consistent ❤️

(Note: of course, it is possible to not specify the `--queues` option at all, but then it becomes hard to script.)