### PR TITLE
Fixes retained memory due to recursive calls

### DIFF
--- a/spec/shoryuken/manager_spec.rb
+++ b/spec/shoryuken/manager_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Shoryuken::Manager do
     specify do
       allow(subject).to receive(:running?).and_return(true, true, false)
       expect(subject).to receive(:dispatch).once.and_call_original
-      expect(subject).to receive(:dispatch_loop).twice.and_call_original
+      expect(subject).to receive(:dispatch_loop).once.and_call_original
       subject.start
     end
   end
@@ -42,8 +42,8 @@ RSpec.describe Shoryuken::Manager do
     end
 
     it 'pauses when there are no active queues' do
-      expect(polling_strategy).to receive(:next_queue).and_return(nil)
-      expect(subject).to receive(:dispatch).and_call_original
+      expect(polling_strategy).to receive(:next_queue).twice.and_return(nil)
+      expect(subject).to_not receive(:dispatch).and_call_original
       subject.start
     end
 
@@ -74,7 +74,7 @@ RSpec.describe Shoryuken::Manager do
       expect(Shoryuken::Processor).to receive(:process).with(q, message)
       expect(Shoryuken.logger).to_not receive(:info)
 
-      subject.send(:dispatch)
+      subject.send(:dispatch, q)
     end
 
     context 'when batch' do
@@ -88,7 +88,7 @@ RSpec.describe Shoryuken::Manager do
         expect(Shoryuken::Processor).to receive(:process).with(q, messages)
         expect(Shoryuken.logger).to_not receive(:info)
 
-        subject.send(:dispatch)
+        subject.send(:dispatch, q)
       end
     end
   end


### PR DESCRIPTION
# Context 

We keep observing the Shoryuken memory growing slowly in production and started debugging to find the root cause.

# The Fix

The previous logic used a recursion for the dispatch loop. The problem with that is that recursive calls only free memory when the recursion resolves.

This PR solves it by using a `while` statement instead of the recursion. 

`rbtrace` and `heapy` were used in order to detect the retained objects, this is one of the head dumps after shoryuken ran for a while:

```
High Ref Counts
==============================

2646  /Users/nakamura/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/shoryuken-3.2.3/lib/shoryuken/manager.rb:31

allocated by memory (19576546) (in bytes)
==============================

84552  /Users/nakamura/.rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/shoryuken-3.2.3/lib/shoryuken/manager.rb:31
```

See the [shoryuken manager code](https://github.com/phstc/shoryuken/blob/master/lib/shoryuken/manager.rb#L31).

It is saving around 80k from memory, in this case, when a `while` statement is used rather than the recursion.

After this fix the `shoryuken/manager` doesn't even show up as part of the `rbtrace` and `heapy` output