### PR TITLE
Log SQS receipt handle

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -40,7 +40,10 @@ module Shoryuken
     end
 
     def receive_messages(options)
-      client.receive_message(options.merge(queue_url: url)).messages.map { |m| Message.new(client, self, m) }
+      client.receive_message(options.merge(queue_url: url)).messages.map do |m|
+        logger.info { "Received message from SQS(#{name}), message_id: #{m.message_id}, receipt_handle: #{m.receipt_handle}" }
+        Message.new(client, self, m)
+      end
     end
 
     def fifo?


### PR DESCRIPTION
I'd like to know the receipt handle for deleting a message which cause error.

my case:
Some Active Jobs ran on Shoryuken and one of them always raised an error from its condition. I tried to delete the job but couldn't because of SQS invisibility.