### PR TITLE
Make it possible to send options to JSON.parse

### DIFF
--- a/lib/shoryuken/body_parser.rb
+++ b/lib/shoryuken/body_parser.rb
@@ -2,11 +2,13 @@ module Shoryuken
   class BodyParser
     class << self
       def parse(worker_class, sqs_msg)
-        body_parser = worker_class.get_shoryuken_options['body_parser']
+        options = worker_class.get_shoryuken_options
+        body_parser = options['body_parser']
 
         case body_parser
         when :json
-          JSON.parse(sqs_msg.body)
+          json_options = options['json_parse'] || {}
+          JSON.parse(sqs_msg.body, json_options)
         when Proc
           body_parser.call(sqs_msg)
         when :text, nil

--- a/spec/shoryuken/body_parser_spec.rb
+++ b/spec/shoryuken/body_parser_spec.rb
@@ -15,6 +15,16 @@ RSpec.describe Shoryuken::BodyParser do
       expect(described_class.parse(TestWorker, sqs_msg)).to eq(body)
     end
 
+    it 'invokes JSON.parse with the extra options' do
+      TestWorker.get_shoryuken_options['body_parser'] = :json
+      TestWorker.get_shoryuken_options['json_parse'] = { symbolize_names: true }
+
+      allow(sqs_msg).to receive(:body).and_return({})
+      expect(JSON).to receive(:parse).with({}, { symbolize_names: true })
+
+      described_class.parse(TestWorker, sqs_msg)
+    end
+
     it 'parses the body calling the proc' do
       TestWorker.get_shoryuken_options['body_parser'] = proc { |sqs_msg| "*#{sqs_msg.body}*" }
 


### PR DESCRIPTION
It would be nice to be able to send options to `JSON.parse` through the main options:
 `shoryuken_options body_parser: :json, json_parse: { symbolize_names: true }`