### PR TITLE
Memoize Shoryuken::Queue#visibility_timeout to avoid hitting SQS API multiple times

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -14,7 +14,7 @@ module Shoryuken
     end
 
     def visibility_timeout
-      queue_attributes.attributes[VISIBILITY_TIMEOUT_ATTR].to_i
+      @visibility_timeout ||= queue_attributes.attributes[VISIBILITY_TIMEOUT_ATTR].to_i
     end
 
     def delete_messages(options)


### PR DESCRIPTION
Add some memoization on Shoryuken::Queue#visibility_timeout to avoid hitting SQS API multiple times.