### PR TITLE
Fix the delegated methods to public

### DIFF
--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -199,6 +199,18 @@ module Shoryuken
         options[:lifecycle_events][event] << block
       end
 
+      def server?
+        defined?(Shoryuken::CLI)
+      end
+
+      def cache_visiblity_timeout?
+        @@cache_visiblity_timeout
+      end
+
+      def cache_visiblity_timeout=(cache_visiblity_timeout)
+        @@cache_visiblity_timeout = cache_visiblity_timeout
+      end
+
       private
 
       def default_server_middleware
@@ -216,18 +228,6 @@ module Shoryuken
 
       def default_client_middleware
         Middleware::Chain.new
-      end
-
-      def server?
-        defined?(Shoryuken::CLI)
-      end
-
-      def cache_visiblity_timeout?
-        @@cache_visiblity_timeout
-      end
-
-      def cache_visiblity_timeout=(cache_visiblity_timeout)
-        @@cache_visiblity_timeout = cache_visiblity_timeout
       end
     end
   end


### PR DESCRIPTION
I fixed the following warnings on Ruby 2.4 or later:
```
/home/vagrant/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/shoryuken-4.0.1/lib/shoryuken/queue.rb:19: warning: Shoryuken#cache_visiblity_timeout? at /home/vagrant/.rbenv/versions/2.5.1/lib/ruby/2.5.0/forwardable.rb:289 forwarding to private method Class#cache_visiblity_timeout?
```

Ruby 2.3 or earlier has not occurred.
https://travis-ci.org/phstc/shoryuken/jobs/458056202
https://travis-ci.org/phstc/shoryuken/jobs/458056204
https://travis-ci.org/phstc/shoryuken/jobs/458056206
https://travis-ci.org/phstc/shoryuken/jobs/458056208

Ruby 2.4 or later has occurred.
https://travis-ci.org/phstc/shoryuken/jobs/458056210
https://travis-ci.org/phstc/shoryuken/jobs/458056212