### PR TITLE
Specify exception class to `raise_error` matcher

### DIFF
--- a/spec/shoryuken/middleware/server/auto_extend_visibility_spec.rb
+++ b/spec/shoryuken/middleware/server/auto_extend_visibility_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Shoryuken::Middleware::Server::AutoExtendVisibility do
     allow(sqs_msg).to receive(:queue) { sqs_queue }
     expect(sqs_msg).to_not receive(:change_visibility)
 
-    expect { Runner.new.run_and_raise(TestWorker.new, queue, sqs_msg) }.to raise_error
+    expect { Runner.new.run_and_raise(TestWorker.new, queue, sqs_msg) }.to raise_error(RuntimeError)
   end
 
   it 'does not extend message visibility if auto_visibility_timeout is not true' do


### PR DESCRIPTION
Fixed a following warning:
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was RuntimeError.  Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /home/travis/build/phstc/shoryuken/spec/shoryuken/middleware/server/auto_extend_visibility_spec.rb:56:in `block (2 levels) in <top (required)>'.
```
https://travis-ci.org/phstc/shoryuken/jobs/458056177#L588