### PR TITLE
Fix spelling of "visibility" 

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -78,8 +78,8 @@ module Shoryuken
     :on_start,
     :on_stop,
     :on,
-    :cache_visiblity_timeout?,
-    :cache_visiblity_timeout=
+    :cache_visibility_timeout?,
+    :cache_visibility_timeout=
   )
 end
 

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -23,7 +23,7 @@ module Shoryuken
     @@stop_callback                   = nil
     @@worker_executor                 = Worker::DefaultExecutor
     @@launcher_executor               = nil
-    @@cache_visiblity_timeout         = false
+    @@cache_visibility_timeout         = false
 
     class << self
       def active_job?
@@ -222,12 +222,12 @@ module Shoryuken
         defined?(Shoryuken::CLI)
       end
 
-      def cache_visiblity_timeout?
-        @@cache_visiblity_timeout
+      def cache_visibility_timeout?
+        @@cache_visibility_timeout
       end
 
-      def cache_visiblity_timeout=(cache_visiblity_timeout)
-        @@cache_visiblity_timeout = cache_visiblity_timeout
+      def cache_visibility_timeout=(cache_visibility_timeout)
+        @@cache_visibility_timeout = cache_visibility_timeout
       end
     end
   end

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -23,7 +23,7 @@ module Shoryuken
     @@stop_callback                   = nil
     @@worker_executor                 = Worker::DefaultExecutor
     @@launcher_executor               = nil
-    @@cache_visibility_timeout         = false
+    @@cache_visibility_timeout        = false
 
     class << self
       def active_job?

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -14,9 +14,9 @@ module Shoryuken
     end
 
     def visibility_timeout
-      # Always lookup for the latest visiblity when cache is disabled
+      # Always lookup for the latest visibility when cache is disabled
       # setting it to nil, forces re-lookup
-      @_visibility_timeout = nil unless Shoryuken.cache_visiblity_timeout?
+      @_visibility_timeout = nil unless Shoryuken.cache_visibility_timeout?
       @_visibility_timeout ||= queue_attributes.attributes[VISIBILITY_TIMEOUT_ATTR].to_i
     end
 

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe Shoryuken::Queue do
     end
   end
 
-  describe '#visiblity_timeout' do
+  describe '#visibility_timeout' do
     let(:attribute_response) { double 'Aws::SQS::Types::GetQueueAttributesResponse' }
 
     before do
@@ -247,7 +247,7 @@ RSpec.describe Shoryuken::Queue do
 
     context 'when cache is disabled' do
       specify do
-        Shoryuken.cache_visiblity_timeout = false
+        Shoryuken.cache_visibility_timeout = false
 
         expect(sqs).to(
           receive(:get_queue_attributes).with(queue_url: queue_url, attribute_names: ['All']).and_return(attribute_response).exactly(3).times
@@ -260,7 +260,7 @@ RSpec.describe Shoryuken::Queue do
 
     context 'when cache is enabled' do
       it 'memoizes response' do
-        Shoryuken.cache_visiblity_timeout = true
+        Shoryuken.cache_visibility_timeout = true
 
         expect(sqs).to(
           receive(:get_queue_attributes).with(queue_url: queue_url, attribute_names: ['All']).and_return(attribute_response).once

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,7 +61,7 @@ RSpec.configure do |config|
 
     Shoryuken.sqs_client_receive_message_opts.clear
 
-    Shoryuken.cache_visiblity_timeout = false
+    Shoryuken.cache_visibility_timeout = false
 
     allow(Concurrent).to receive(:global_io_executor).and_return(Concurrent::ImmediateExecutor.new)
     allow(Shoryuken).to receive(:active_job?).and_return(false)


### PR DESCRIPTION
It was misspelled "visiblity" in some places.