### PR TITLE
queue names can be any url

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -66,7 +66,7 @@ module Shoryuken
     end
 
     def set_name_and_url(name_or_url)
-      if name_or_url.start_with?('https://sqs.')
+      if name_or_url.include?('://')
         set_by_url(name_or_url)
 
         # anticipate the fifo? checker for validating the queue URL


### PR DESCRIPTION
Previously, you could pass a queue name, or a queue url to shoryuken, as long as the url started with `https://sqs.`. This form works for many situations, but not when incorporating shoryuken with localstack. Localstack's sqs urls don't have the leading `sqs.`. You cannot pass the queue name to shoryuken when using localstack, because localstack doesn't implement get_queue_url yet. 

This PR relaxes the url constraint. Instead of having to start with `https://sqs.`, now the name will be treated as a url if it contains `://`. 
