### PR TITLE
CI: Add 2.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.3.8
   - 2.4.4
   - 2.5.1
+  - 2.6.3
 
 notifications:
   email:


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rvm/rvm/blob/master/config/known