### PR TITLE
Load rails before parsing queues

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -24,7 +24,6 @@ module Shoryuken
     end
 
     def load
-      load_rails if Shoryuken.options[:rails]
       prefix_active_job_queue_names
       parse_queues
       require_workers
@@ -54,26 +53,6 @@ module Shoryuken
     def initialize_logger
       Shoryuken::Logging.initialize_logger(Shoryuken.options[:logfile]) if Shoryuken.options[:logfile]
       Shoryuken.logger.level = Logger::DEBUG if Shoryuken.options[:verbose]
-    end
-
-    def load_rails
-      # Adapted from: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/cli.rb
-
-      require 'rails'
-      if ::Rails::VERSION::MAJOR < 4
-        require File.expand_path('config/environment.rb')
-        ::Rails.application.eager_load!
-      else
-        # Painful contortions, see 1791 for discussion
-        require File.expand_path('config/application.rb')
-        if ::Rails::VERSION::MAJOR == 4
-          ::Rails::Application.initializer 'shoryuken.eager_load' do
-            ::Rails.application.config.eager_load = true
-          end
-        end
-        require 'shoryuken/extensions/active_job_adapter' if Shoryuken.active_job?
-        require File.expand_path('config/environment.rb')
-      end
     end
 
     def merge_cli_defined_queues

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#parse_queues loads default queues' do
     before do
-      allow(subject).to receive(:load_rails)
       allow(subject).to receive(:prefix_active_job_queue_names)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
@@ -24,7 +23,6 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#parse_queues includes delay per groups' do
     before do
-      allow(subject).to receive(:load_rails)
       allow(subject).to receive(:prefix_active_job_queue_names)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
@@ -47,7 +45,6 @@ RSpec.describe Shoryuken::EnvironmentLoader do
 
   describe '#prefix_active_job_queue_names' do
     before do
-      allow(subject).to receive(:load_rails)
       allow(subject).to receive(:require_workers)
       allow(subject).to receive(:validate_queues)
       allow(subject).to receive(:validate_workers)


### PR DESCRIPTION
### Context
Configuration loading files like dotenv and figaro need to be loaded before Shoryuken parses the shoryuken config file, which may contain environment variables

### Changes
- Moved `load_rails` method from `EnvironmentLoader` to `Shoryuken::Runner`