### PR TITLE
Suppress `warning: method redefined`

### DIFF
--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -14,9 +14,11 @@ module Shoryuken
       }
     }.freeze
 
-    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout, :default_worker_options, :groups,
-                  :launcher_executor, :sqs_client, :sqs_client_receive_message_opts,
+    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout, :groups,
+                  :launcher_executor,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry
+    attr_writer :default_worker_options, :sqs_client
+    attr_reader :sqs_client_receive_message_opts
 
     def initialize
       self.groups = {}


### PR DESCRIPTION
This PR suppresses the following warning.

```
ruby -v
ruby 2.6.4p104 (2019-08-28 revision 67798) [x86_64-linux]

RUBYOPT=-w bundle exec rspec
/shoryuken/options.rb:74: warning: method redefined; discarding old sqs_client
/shoryuken/options.rb:78: warning: method redefined; discarding old sqs_client_receive_message_opts=
/shoryuken/lib/shoryuken/options.rb:114: warning: method redefined; discarding old default_worker_options
```