### PR TITLE
Remove EnvironmentLoader#merge_cli_defined_queues

### DIFF
--- a/lib/shoryuken/environment_loader.rb
+++ b/lib/shoryuken/environment_loader.rb
@@ -20,7 +20,6 @@ module Shoryuken
     def setup_options
       initialize_options
       initialize_logger
-      merge_cli_defined_queues
     end
 
     def load
@@ -73,17 +72,6 @@ module Shoryuken
         end
         require 'shoryuken/extensions/active_job_adapter' if Shoryuken.active_job?
         require File.expand_path('config/environment.rb')
-      end
-    end
-
-    def merge_cli_defined_queues
-      cli_defined_queues = options[:queues].to_a
-
-      cli_defined_queues.each do |cli_defined_queue|
-        # CLI defined queues override config_file defined queues
-        Shoryuken.options[:queues].delete_if { |config_file_queue| config_file_queue[0] == cli_defined_queue[0] }
-
-        Shoryuken.options[:queues] << cli_defined_queue
       end
     end
 

--- a/spec/shoryuken/environment_loader_spec.rb
+++ b/spec/shoryuken/environment_loader_spec.rb
@@ -74,4 +74,28 @@ RSpec.describe Shoryuken::EnvironmentLoader do
       expect(Shoryuken.groups['group1'][:queues]).to eq(%w[test_group1_queue1 test_group1_queue2])
     end
   end
+  describe "#setup_options" do
+    let (:cli_queues) { { "queue1"=> 10, "queue2" => 20 } }
+    let (:config_queues) { [["queue1", 8], ["queue2", 4]] }
+    context "when given queues through config and CLI" do
+      specify do
+        allow_any_instance_of(Shoryuken::EnvironmentLoader).to receive(:config_file_options).and_return({ queues: config_queues })
+        Shoryuken::EnvironmentLoader.setup_options(queues: cli_queues)
+        expect(Shoryuken.options[:queues]).to eq(cli_queues)
+      end
+    end
+    context "when given queues through config only" do
+      specify do
+        allow_any_instance_of(Shoryuken::EnvironmentLoader).to receive(:config_file_options).and_return({ queues: config_queues })
+        Shoryuken::EnvironmentLoader.setup_options({})
+        expect(Shoryuken.options[:queues]).to eq(config_queues)
+      end
+    end
+    context "when given queues through CLI only" do
+      specify do
+        Shoryuken::EnvironmentLoader.setup_options(queues: cli_queues)
+        expect(Shoryuken.options[:queues]).to eq(cli_queues)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### What did you do?

Removed a method from EnvironmentLoader which caused an issue with queue order

### Why?

This method is not needed as CLI options are merged overtop of config options in
EnvironmentLoader#initialize_options

see https://github.com/phstc/shoryuken/issues/552 for further details