### PR TITLE
Deliver Messages Async

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are using AWS SDK version 3, please also add this line:
 gem 'aws-sdk-sqs'
 ```
 
-The extra gem `aws-sdk-sqs` is required in order to keep Shoryuken compatible with AWS SDK version 2 and 3. 
+The extra gem `aws-sdk-sqs` is required in order to keep Shoryuken compatible with AWS SDK version 2 and 3.
 
 And then execute:
 

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -86,12 +86,14 @@ RSpec.describe Shoryuken::Queue do
       expect(sqs).to receive(:send_message).with(hash_including(message_body: 'msg1'))
 
       subject.send_message(message_body: 'msg1')
+      sleep(0.0001)
     end
 
     it 'accepts a string' do
       expect(sqs).to receive(:send_message).with(hash_including(message_body: 'msg1'))
 
       subject.send_message('msg1')
+      sleep(0.0001)
     end
 
     context 'when a client middleware' do


### PR DESCRIPTION
Prior to this change delivering 5000 messages took on average:

    user     system      total        real
    6.351633   0.535708   6.887341 ( 42.842282)

After this change, I am able to delivery 5000 messages in:

    user     system      total        real
    7.160261   1.237327   8.397588 (  7.676820)

In my rough benchmarks I see a 5-7x increase.  This is valuable for us because we enqueue a large number of jobs at once in a loop, something akin to:

```ruby
MyModel.expensive_query.select(:id).each { |obj| MyJob.perform_later(obj) }
```

A couple call outs:

1.  I was unsure if this should be configurable (ie async vs blocking)
2.  Tests either need to call `sleep` to allow the executor to work or I need to mock differently.  I'm open to either but thought I'd check first
3.  In addition to on/off configuration, I'm wondering if options sent to `Concurrent::CachedThreadPool.new` should also be configurable.