### PR TITLE
Deliver Messages Async

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are using AWS SDK version 3, please also add this line:
 gem 'aws-sdk-sqs'
 ```
 
-The extra gem `aws-sdk-sqs` is required in order to keep Shoryuken compatible with AWS SDK version 2 and 3. 
+The extra gem `aws-sdk-sqs` is required in order to keep Shoryuken compatible with AWS SDK version 2 and 3.
 
 And then execute:
 

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -88,4 +88,7 @@ module Shoryuken
   )
 end
 
-require 'shoryuken/extensions/active_job_adapter' if Shoryuken.active_job?
+if Shoryuken.active_job?
+  require 'shoryuken/extensions/active_job_adapter'
+  require 'shoryuken/extensions/active_job_concurrent_send_adapter'
+end

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -1,7 +1,7 @@
 module Shoryuken
   class DefaultWorkerRegistry < WorkerRegistry
     def initialize
-      @workers = {}
+      @workers = Concurrent::Hash.new
     end
 
     def batch_receive_messages?(queue)

--- a/lib/shoryuken/extensions/active_job_concurrent_send_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_concurrent_send_adapter.rb
@@ -1,43 +1,42 @@
 # ActiveJob docs: http://edgeguides.rubyonrails.org/active_job_basics.html
 # Example adapters ref: https://github.com/rails/rails/tree/master/activejob/lib/active_job/queue_adapters
- module ActiveJob
-   module QueueAdapters
-     # == Shoryuken concurrent adapter for Active Job
-     #
-     # This adapter sends messages asynchronously (ie non-blocking) and allows
-     # the caller to set up handlers for both success and failure
-     #
-     # To use this adapter, set up as:
-     #
-     # adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new
-		 # adapter.success_handler = ->(job, options) { StatsD.increment(job.class.name + "success") }
-		 # adapter.error_handler = ->(err, (job, options)) { StatsD.increment(job.class.name + "failure") }
-		 #
-		 # config.active_job.queue_adapter = adapter
-     class ShoryukenConcurrentSendAdapter < ShoryukenAdapter
+module ActiveJob
+  module QueueAdapters
+    # == Shoryuken concurrent adapter for Active Job
+    #
+    # This adapter sends messages asynchronously (ie non-blocking) and allows
+    # the caller to set up handlers for both success and failure
+    #
+    # To use this adapter, set up as:
+    #
+    # adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new
+    # adapter.success_handler = ->(job, options) { StatsD.increment(job.class.name + "success") }
+    # adapter.error_handler = ->(err, (job, options)) { StatsD.increment(job.class.name + "failure") }
+    #
+    # config.active_job.queue_adapter = adapter
+    class ShoryukenConcurrentSendAdapter < ShoryukenAdapter
+      attr_accessor :error_handler
+      attr_accessor :success_handler
 
-       attr_accessor :error_handler
-       attr_accessor :success_handler
+      def initialize
+        self.error_handler = lambda { |error, job, _options|
+          Shoryuken.logger.warn("Failed to enqueue job: #{job.inspect} due to error: #{error}")
+        }
+        self.success_handler = ->(_job, _options) { nil }
+      end
 
-       def initialize
-				 self.error_handler = ->(error, job, options) do
-					 Shoryuken.logger.warn("Failed to enqueue job: #{job.inspect} due to error: #{error}")
-				 end
-         self.success_handler = ->(_job, _options) { nil }
-       end
+      def enqueue(job, options = {})
+        send_concurrently(job, options) { |f_job, f_options| super(f_job, f_options) }
+      end
 
-       def enqueue(job, options = {})
-         send_concurrently(job, options) { |job, options| super(job, options) }
-       end
+      private
 
-       private
-
-       def send_concurrently(job, options)
-         Concurrent::Promises
-					 .future(job, options) { |f_job, f_options| yield(f_job, f_options) }
-           .then(job, options) { |f_job, f_options| success_handler.call(f_job, f_options) }
-           .rescue(job, options) { |err, (f_job, f_options)| error_handler.call(err, f_job, f_options) }
-       end
-     end
-   end
- end
+      def send_concurrently(job, options)
+        Concurrent::Promises
+          .future(job, options) { |f_job, f_options| yield(f_job, f_options) }
+          .then(job, options) { |f_job, f_options| success_handler.call(f_job, f_options) }
+          .rescue(job, options) { |err, (f_job, f_options)| error_handler.call(err, f_job, f_options) }
+      end
+    end
+  end
+end

--- a/lib/shoryuken/extensions/active_job_concurrent_send_adapter.rb
+++ b/lib/shoryuken/extensions/active_job_concurrent_send_adapter.rb
@@ -1,0 +1,26 @@
+ module ActiveJob
+   module QueueAdapters
+     class ShoryukenConcurrentSendAdapter < ShoryukenAdapter
+
+       attr_accessor :error_handler
+       attr_accessor :success_handler
+
+       def initialize
+         @error_handler = ->(error, job, options) { Shoryuken.logger.warn("Failed to enqueue job: #{job.inspect} due to error: #{error}") }
+         @success_handler = ->(job, options) { nil }
+       end
+
+       def enqueue(job, options = {})
+         send_concurrently(job, options) { |job, options| super(job, options) }
+       end
+
+       private
+
+       def send_concurrently(job, options)
+         Concurrent::Promises.future(job, options) { |job, options| yield(job, options) }
+           .then(job, options) { |job, options| success_handler.call(job, options) }
+           .rescue(job, options) { |err, (job, options)| error_handler.call(err, job, options) }
+       end
+     end
+   end
+ end

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -1,0 +1,61 @@
+RSpec.shared_examples "active_job_adapters" do
+  let(:job) { double 'Job', id: '123', queue_name: 'queue' }
+  let(:fifo) { false }
+  let(:queue) { double 'Queue', fifo?: fifo }
+
+  before do
+    allow(Shoryuken::Client).to receive(:queues).with(job.queue_name).and_return(queue)
+    allow(job).to receive(:serialize).and_return(
+      'job_class' => 'Worker',
+      'job_id'     => job.id,
+      'queue_name' => job.queue_name,
+      'arguments'  => nil,
+      'locale'     => nil
+    )
+  end
+
+  describe '#enqueue' do
+    specify do
+      expect(queue).to receive(:send_message) do |hash|
+        expect(hash[:message_deduplication_id]).to_not be
+      end
+      expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
+
+      subject.enqueue(job)
+    end
+
+    context 'when fifo' do
+      let(:fifo) { true }
+
+      it 'does not include job_id in the deduplication_id' do
+        expect(queue).to receive(:send_message) do |hash|
+          message_deduplication_id = Digest::SHA256.hexdigest(JSON.dump(job.serialize.except('job_id')))
+
+          expect(hash[:message_deduplication_id]).to eq(message_deduplication_id)
+        end
+        expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
+
+        subject.enqueue(job)
+      end
+    end
+  end
+
+  describe '#enqueue_at' do
+    specify do
+      delay = 1
+
+      expect(queue).to receive(:send_message) do |hash|
+        expect(hash[:message_deduplication_id]).to_not be
+        expect(hash[:delay_seconds]).to eq(delay)
+      end
+
+      expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
+
+      # need to figure out what to require Time.current and N.minutes to remove the stub
+      allow(subject).to receive(:calculate_delay).and_return(delay)
+
+      subject.enqueue_at(job, nil)
+    end
+  end
+
+end

--- a/spec/shoryuken/extensions/active_job_adapter_spec.rb
+++ b/spec/shoryuken/extensions/active_job_adapter_spec.rb
@@ -1,64 +1,7 @@
 require 'spec_helper'
-require 'active_job'
 require 'shoryuken/extensions/active_job_adapter'
+require 'shared_examples_for_active_job'
 
 RSpec.describe ActiveJob::QueueAdapters::ShoryukenAdapter do
-  let(:job) { double 'Job', id: '123', queue_name: 'queue' }
-  let(:fifo) { false }
-  let(:queue) { double 'Queue', fifo?: fifo }
-
-  before do
-    allow(Shoryuken::Client).to receive(:queues).with(job.queue_name).and_return(queue)
-    allow(job).to receive(:serialize).and_return(
-      'job_class' => 'Worker',
-      'job_id'     => job.id,
-      'queue_name' => job.queue_name,
-      'arguments'  => nil,
-      'locale'     => nil
-    )
-  end
-
-  describe '#enqueue' do
-    specify do
-      expect(queue).to receive(:send_message) do |hash|
-        expect(hash[:message_deduplication_id]).to_not be
-      end
-      expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
-
-      subject.enqueue(job)
-    end
-
-    context 'when fifo' do
-      let(:fifo) { true }
-
-      it 'does not include job_id in the deduplication_id' do
-        expect(queue).to receive(:send_message) do |hash|
-          message_deduplication_id = Digest::SHA256.hexdigest(JSON.dump(job.serialize.except('job_id')))
-
-          expect(hash[:message_deduplication_id]).to eq(message_deduplication_id)
-        end
-        expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
-
-        subject.enqueue(job)
-      end
-    end
-  end
-
-  describe '#enqueue_at' do
-    specify do
-      delay = 1
-
-      expect(queue).to receive(:send_message) do |hash|
-        expect(hash[:message_deduplication_id]).to_not be
-        expect(hash[:delay_seconds]).to eq(delay)
-      end
-
-      expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
-
-      # need to figure out what to require Time.current and N.minutes to remove the stub
-      allow(subject).to receive(:calculate_delay).and_return(delay)
-
-      subject.enqueue_at(job, nil)
-    end
-  end
+  include_examples "active_job_adapters"
 end

--- a/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
+++ b/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
@@ -4,4 +4,26 @@ require 'shoryuken/extensions/active_job_concurrent_send_adapter'
 
 RSpec.describe ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter do
   include_examples "active_job_adapters"
+
+  context "#success_hander" do
+    it "is called when a job succeeds" do
+      options = {}
+      response = true
+      allow(queue).to receive(:send_message).and_return(response)
+      expect(subject.success_handler).to receive(:call).with(response, job, options)
+
+      subject.enqueue(job, options)
+    end
+  end
+
+  context "#error_handler" do
+    it "is called when sending a job fails" do
+      options = {}
+      response = Aws::SQS::Errors::InternalError.new("error", "error")
+      allow(queue).to receive(:send_message).and_raise(response)
+      expect(subject.error_handler).to receive(:call).with(response, job, options).and_call_original
+
+      subject.enqueue(job, options)
+    end
+  end
 end

--- a/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
+++ b/spec/shoryuken/extensions/active_job_concurrent_send_adapter_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+require 'shared_examples_for_active_job'
+require 'shoryuken/extensions/active_job_concurrent_send_adapter'
+
+RSpec.describe ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter do
+  include_examples "active_job_adapters"
+end


### PR DESCRIPTION
Prior to this change delivering 5000 messages took on average:

    user     system      total        real
    6.351633   0.535708   6.887341 ( 42.842282)

After this change, I am able to delivery 5000 messages in:

    user     system      total        real
    7.160261   1.237327   8.397588 (  7.676820)

In my rough benchmarks I see a 5-7x increase.  This is valuable for us because we enqueue a large number of jobs at once in a loop, something akin to:

```ruby
MyModel.expensive_query.each { |obj| MyJob.perform_later(obj) }
```

Usable by setting:

```ruby
config.active_job.queue_adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new
```

Handlers are available for both success and failure and must respond to
call.

Example:

```ruby
adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new
adapter.success_handler = ->(job, options) { StatsD.increment(job.class.name + "success") }
adapter.error_handler = ->(err, (job, options)) { StatsD.increment(job.class.name + "failure") }

config.active_job.queue_adapter = adapter
```