### PR TITLE
Message level visibility timeout

### DIFF
--- a/lib/shoryuken/message.rb
+++ b/lib/shoryuken/message.rb
@@ -1,12 +1,16 @@
 module Shoryuken
   class Message
     attr_accessor :client, :queue_url, :queue_name, :data
+    attr_reader :become_available_at, :visibility_timeout
 
     def initialize(client, queue, data)
       self.client     = client
       self.data       = data
       self.queue_url  = queue.url
       self.queue_name = queue.name
+
+      @visibility_timeout = Shoryuken::Client.queues(queue).visibility_timeout
+      self.become_available_at = Time.now + @visibility_timeout
     end
 
     def delete
@@ -28,6 +32,8 @@ module Shoryuken
         receipt_handle: data.receipt_handle,
         visibility_timeout: timeout
       )
+      @visibility_timeout = timeout
+      self.become_available_at = Time.now + timeout
     end
 
     def message_id

--- a/spec/shoryuken/processor_spec.rb
+++ b/spec/shoryuken/processor_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Shoryuken::Processor do
       body: 'test',
       message_attributes: {},
       message_id: SecureRandom.uuid,
-      receipt_handle: SecureRandom.uuid
+      receipt_handle: SecureRandom.uuid,
+      become_available_at: Time.now + 1_200
     )
   end
 
@@ -145,7 +146,8 @@ RSpec.describe Shoryuken::Processor do
             }
           },
           message_id: SecureRandom.uuid,
-          receipt_handle: SecureRandom.uuid
+          receipt_handle: SecureRandom.uuid,
+          become_available_at: Time.now + 1_200
         )
       end
 


### PR DESCRIPTION
This PR tries to address #591, it

- Adds the ability to query `visibility_timeout` from message level
- Changes the logic inside `Timing` middleware to print "exceeds visibility timeout" warning according to message level `visibility_timeout`