### PR TITLE
Add endpoint option to SQS CLI

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -5,6 +5,7 @@ module Shoryuken
   module CLI
     class SQS < Base
       namespace :sqs
+      class_option :endpoint, aliases: '-e', type: :string, default: ENV['SHORYUKEN_SQS_ENDPOINT'], desc: 'Endpoint URL'
 
       no_commands do
         def normalize_dump_message(message)
@@ -19,8 +20,15 @@ module Shoryuken
           }
         end
 
+        def client_options
+          endpoint = options[:endpoint]
+          {}.tap do |hash|
+            hash[:endpoint] = endpoint unless endpoint.to_s.empty?
+          end
+        end
+
         def sqs
-          @_sqs ||= Aws::SQS::Client.new
+          @_sqs ||= Aws::SQS::Client.new(client_options)
         end
 
         def find_queue_url(queue_name)


### PR DESCRIPTION
I use [Localstack](https://github.com/localstack/localstack) for local development. I can successfully point `shoryuken start` at my localstack endpoint by configuring SQS in a Rails initializer and passing the `--rails/-R` option. However, I can't do anything similar to point `shoryuken sqs` at my localstack endpoint.

This change introduces an endpoint class option for the SQS CLI. Now, the CLI's SQS client is initialized with the provided endpoint if one is provided. The option can be set by passing `--endpoint`, `-e`, or setting the `SHORYUKEN_SQS_ENDPOINT` environment variable.

I considered instead passing the existing `--rails/-R` option and running through the same environment loading that takes places in the Shoryuken CLI, but that felt like overkill here - especially because running through all of the Rails initialization could add a lot of startup time to these SQS commands. Please let me know if you disagree with that decision or if there's anything else I can do to help get this merged! Thanks!