### PR TITLE
add ability to configure queue by ARN

### DIFF
--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -65,12 +65,28 @@ module Shoryuken
       self.url  = url
     end
 
+    def arn_to_url(arn_str)
+      _,_,_,region,account_id,resource = arn_str.split(":")
+
+      required = [region, account_id, resource]
+
+      raise "please pass a shoryuken queue ARN containing, account_id, and resource values (#{arn_str})" if required.any?(&:empty?)
+
+      result = "https://sqs.#{region}.amazonaws.com/#{account_id}/#{resource}"
+    end
+
     def set_name_and_url(name_or_url)
       if name_or_url.include?('://')
         set_by_url(name_or_url)
 
         # anticipate the fifo? checker for validating the queue URL
         return fifo?
+      end
+
+      if name_or_url.include?('arn:')
+        url = arn_to_url(name_or_url)
+        set_by_url(url)
+        return
       end
 
       set_by_name(name_or_url)

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -66,13 +66,14 @@ module Shoryuken
     end
 
     def arn_to_url(arn_str)
-      _,_,_,region,account_id,resource = arn_str.split(":")
+      _, _, _, region, account_id, resource = arn_str.split(':')
 
       required = [region, account_id, resource]
+      valid = required.none?(&:empty?)
 
-      raise "please pass a shoryuken queue ARN containing, account_id, and resource values (#{arn_str})" if required.any?(&:empty?)
+      raise "please pass a shoryuken queue ARN containing, account_id, and resource values (#{arn_str})" unless valid
 
-      result = "https://sqs.#{region}.amazonaws.com/#{account_id}/#{resource}"
+      "https://sqs.#{region}.amazonaws.com/#{account_id}/#{resource}"
     end
 
     def set_name_and_url(name_or_url_or_arn)

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -8,9 +8,9 @@ module Shoryuken
 
     attr_accessor :name, :client, :url
 
-    def initialize(client, name_or_url)
+    def initialize(client, name_or_url_or_arn)
       self.client = client
-      set_name_and_url(name_or_url)
+      set_name_and_url(name_or_url_or_arn)
     end
 
     def visibility_timeout
@@ -75,23 +75,23 @@ module Shoryuken
       result = "https://sqs.#{region}.amazonaws.com/#{account_id}/#{resource}"
     end
 
-    def set_name_and_url(name_or_url)
-      if name_or_url.include?('://')
-        set_by_url(name_or_url)
+    def set_name_and_url(name_or_url_or_arn)
+      if name_or_url_or_arn.include?('://')
+        set_by_url(name_or_url_or_arn)
 
         # anticipate the fifo? checker for validating the queue URL
         return fifo?
       end
 
-      if name_or_url.include?('arn:')
-        url = arn_to_url(name_or_url)
+      if name_or_url_or_arn.include?('arn:')
+        url = arn_to_url(name_or_url_or_arn)
         set_by_url(url)
         return
       end
 
-      set_by_name(name_or_url)
+      set_by_name(name_or_url_or_arn)
     rescue Aws::Errors::NoSuchEndpointError, Aws::SQS::Errors::NonExistentQueue => ex
-      raise ex, "The specified queue #{name_or_url} does not exist."
+      raise ex, "The specified queue #{name_or_url_or_arn} does not exist."
     end
 
     def queue_attributes

--- a/spec/shoryuken/queue_spec.rb
+++ b/spec/shoryuken/queue_spec.rb
@@ -39,6 +39,27 @@ RSpec.describe Shoryuken::Queue do
       end
     end
 
+    context 'when queue ARN supplied' do
+      let(:queue_arn) { "arn:aws:sqs:ap-southeast-2:000000000000:queue-name" }
+
+      it 'instantiates by URL and validate the URL' do
+        subject = described_class.new(sqs, queue_arn)
+
+        expect(subject.name).to eq("queue-name")
+        expect(subject.url).to eq("https://sqs.ap-southeast-2.amazonaws.com/000000000000/queue-name")
+      end
+    end
+
+    context 'when inadequate queue ARN supplied' do
+      let(:queue_arn) { "arn:aws:sqs::000000000000:queue-name" }
+
+      it 'raises an error' do
+        expect do
+          described_class.new(sqs, queue_arn)
+        end.to raise_error("please pass a shoryuken queue ARN containing, account_id, and resource values (arn:aws:sqs::000000000000:queue-name)")
+      end
+    end
+
     context 'when queue name supplied' do
       subject { described_class.new(sqs, queue_name) }
 


### PR DESCRIPTION
This is my first pass at adding the ability to set queue location as an ARN value.

I removed use of the AWS parser as it violates the `'aws-sdk-core', '>= 2'` dependency (it was only added recently) and I don't think it was intended for outside use anyway.

Related: #602 