### PR TITLE
Add behaviour to register_worker

### DIFF
--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -40,7 +40,7 @@ module Shoryuken
         end
       end
 
-      @workers[queue] = clazz
+      @workers[queue] = clazz if !@workers[queue] || clazz.get_shoryuken_options['dispatcher']
     end
 
     def workers(queue)

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -32,15 +32,20 @@ module Shoryuken
     end
 
     def register_worker(queue, clazz)
-      if (worker_class = @workers[queue])
+      worker_class = @workers[queue]
+
+      if worker_class
         if worker_class.get_shoryuken_options['batch'] == true || clazz.get_shoryuken_options['batch'] == true
           fail ArgumentError, "Could not register #{clazz} for #{queue}, "\
             "because #{worker_class} is already registered for this queue, "\
             "and Shoryuken doesn't support a batchable worker for a queue with multiple workers"
+        elsif worker_class.get_shoryuken_options['dispatcher'] == true && clazz.get_shoryuken_options['dispatcher'] == true
+          fail ArgumentError, "Could not register #{clazz} for #{queue}, "\
+            "because #{queue} queue can have only one dispatcher job for queue and #{worker_class} was already registered."
         end
       end
 
-      @workers[queue] = clazz if !@workers[queue] || clazz.get_shoryuken_options['dispatcher']
+      @workers[queue] = clazz if !worker_class || clazz.get_shoryuken_options['dispatcher']
     end
 
     def workers(queue)

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -35,17 +35,20 @@ module Shoryuken
       worker_class = @workers[queue]
 
       if worker_class
-        if worker_class.get_shoryuken_options['batch'] == true || clazz.get_shoryuken_options['batch'] == true
+        worker_class_options = worker_class.get_shoryuken_options
+        clazz_options = clazz.get_shoryuken_options
+
+        if worker_class_options['batch'] == true || clazz_options['batch'] == true
           fail ArgumentError, "Could not register #{clazz} for #{queue}, "\
             "because #{worker_class} is already registered for this queue, "\
             "and Shoryuken doesn't support a batchable worker for a queue with multiple workers"
-        elsif worker_class.get_shoryuken_options['dispatcher'] == true && clazz.get_shoryuken_options['dispatcher'] == true
+        elsif worker_class_options['dispatcher'] == true && clazz_options['dispatcher'] == true
           fail ArgumentError, "Could not register #{clazz} for #{queue}, "\
             "because #{queue} queue can have only one dispatcher job for queue and #{worker_class} was already registered."
         end
       end
 
-      @workers[queue] = clazz if !worker_class || clazz.get_shoryuken_options['dispatcher']
+      @workers[queue] = clazz if !worker_class || clazz_options['dispatcher']
     end
 
     def workers(queue)


### PR DESCRIPTION
# Problem

We will have some Jobs on our application that have the same queue.

Today, if no one queue come on sqs message, the application will get the last job "registered". I think that it behaviour should be more intelligent, so, I changed to register the last dispatcher job.

For example:

### Job A:

```
class AJob
  include Shoryuken::Worker

  shoryuken_options queue: :development_default, auto_delete: true

  def perform(_, args)
    puts "executed_job_a"
  end
end
```

### Job B:

```
class BJob
  include Shoryuken::Worker

  shoryuken_options queue: :development_default, auto_delete: true

  def perform(_, args)
    puts "executed_job_b"
  end
end
```

### So, my dispatcher should be

```
class DispatcherJob
  inclsude Shoryuken::Worker

  shoryuken_options queue: :development_default, auto_delete: true, dispatcher: true, body_parser: true

  def perform(_, sqs_msg)
    if sqs_msg['action'] == 'create'
      JobA.perform_async(sqs_msg)
    elsif sqs_msg['action'] == 'delete'
      JobB.perform_async(sqs_msg)
    end
  end
end
```

So, I can receive, for example, a message from SNS to my queue, and threat in a dispatcher job to choose the destination.

I think that is a generic and useful way to solve our problem.

# Proposed changes

When have a dispatcher worker, he will have priority on register. If a worker already registered, only will be overrided if another worker be a dispatcher.