### PR TITLE
fix release date of v5.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [v5.0.5] - 2020-02-20
+## [v5.0.5] - 2020-06-07
 
 - Add ability to configure queue by ARN
   - [#603](https://github.com/phstc/shoryuken/pull/603)


### PR DESCRIPTION
Fix release date as https://github.com/phstc/shoryuken/releases/tag/v5.0.5

https://github.com/phstc/shoryuken/issues/631