### PR TITLE
Allow message_attributes to be set from ActiveJob clients

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,5 @@
+---
+detectors:
+
+  UtilityFunction:
+    public_methods_only: true

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -19,6 +19,9 @@ RSpec.shared_examples 'active_job_adapters' do
     specify do
       expect(queue).to receive(:send_message) do |hash|
         expect(hash[:message_deduplication_id]).to_not be
+        expect(hash[:message_attributes]['shoryuken_class'][:string_value]).to eq(described_class::JobWrapper.to_s)
+        expect(hash[:message_attributes]['shoryuken_class'][:data_type]).to eq("String")
+        expect(hash[:message_attributes].keys).to eq(['shoryuken_class'])
       end
       expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
 
@@ -37,6 +40,27 @@ RSpec.shared_examples 'active_job_adapters' do
         expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
 
         subject.enqueue(job)
+      end
+    end
+
+    context 'with additional message attributes' do
+      it 'should combine with activejob attributes' do
+        custom_message_attributes = {
+          'tracer_id' => {
+            string_value: SecureRandom.hex,
+            data_type: 'String'
+          }
+        }
+
+        expect(queue).to receive(:send_message) do |hash|
+          expect(hash[:message_attributes]['shoryuken_class'][:string_value]).to eq(described_class::JobWrapper.to_s)
+          expect(hash[:message_attributes]['shoryuken_class'][:data_type]).to eq("String")
+          expect(hash[:message_attributes]['tracer_id'][:string_value]).to eq(custom_message_attributes['tracer_id'][:string_value])
+          expect(hash[:message_attributes]['tracer_id'][:data_type]).to eq("String")
+        end
+        expect(Shoryuken).to receive(:register_worker).with(job.queue_name, described_class::JobWrapper)
+
+        subject.enqueue(job, message_attributes: custom_message_attributes)
       end
     end
   end


### PR DESCRIPTION
We'd like to be able to access the SQS message attributes from the Shoryuken client code and middleware.  Previously, a memoized copy of the needed attributes were used which interfered with middleware when jobs were nested (i.e. ActiveJob clients calling other Active Jobs).  In addition, we had to work implement workarounds for metrics and tracing attributes at that level.

The suggestion here is to allow these to be passed in as options which then get used as the starting point.  The necessary active job attributes are then overwritten on top of any that are passed in to be sure they function the same as before.

We are open to any suggestions on style, thanks!

Co-authored by @tamouse 