### PR TITLE
Use Forwardable within Message to avoid method boilerplate

### DIFF
--- a/lib/shoryuken/message.rb
+++ b/lib/shoryuken/message.rb
@@ -1,6 +1,6 @@
 module Shoryuken
   class Message
-    extend SingleForwardable
+    extend Forwardable
 
     def_delegators(:data,
                    :message_id,


### PR DESCRIPTION
First of all, thank you for maintaining this gem! I really appreciate your efforts. 

While diving into the code I just noticed that a bunch of methods were defined just as a proxy to the data structure. 

As I have seen here: https://github.com/ruby-shoryuken/shoryuken/blob/master/lib/shoryuken.rb#L48 I decided to use the SingleForwardable to delegate to the structure directly.

It's a small thing for now but might the beginning of some contributions