### PR TITLE
stabilize spec

### DIFF
--- a/spec/shoryuken/body_parser_spec.rb
+++ b/spec/shoryuken/body_parser_spec.rb
@@ -69,8 +69,7 @@ RSpec.describe Shoryuken::BodyParser do
       end
 
       specify do
-        expect { described_class.parse(TestWorker, sqs_msg) }
-          .to raise_error(JSON::ParserError, /unexpected character: 'invalid JSON'/)
+        expect { described_class.parse(TestWorker, sqs_msg) }.to raise_error(JSON::ParserError)
       end
     end
 


### PR DESCRIPTION
This error message varies between json gem releases. not worth testing since the error class is self-explanatory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified test to check only for the type of parsing error raised, without requiring a specific error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->