### PR TITLE
explicitly symbolize keys instead of using Hash#symbolize_keys

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -13,7 +13,7 @@ module Shoryuken
       no_commands do
         def normalize_dump_message(message)
           # symbolize_keys is needed for keeping it compatible with `requeue`
-          attributes = message[:attributes].transform_keys { |key| key.to_sym rescue key }
+          attributes = message[:attributes].transform_keys(&:to_sym)
 
           # See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_MessageAttributeValue.html
           # The `string_list_values` and `binary_list_values` are not implemented. Reserved for future use.

--- a/bin/shoryuken
+++ b/bin/shoryuken
@@ -29,7 +29,7 @@ module Shoryuken
       method_option :delay,       aliases: '-D', type: :numeric,
                                   desc: 'Number of seconds to pause fetching from an empty queue'
       def start
-        opts = options.to_h.transform_keys { |key| key.to_sym rescue key }
+        opts = options.to_h.transform_keys(&:to_sym)
 
         say '[DEPRECATED] Please use --config instead of --config-file', :yellow if opts[:config_file]
 


### PR DESCRIPTION
Resolves this error:

```
/usr/local/bundle/bundler/gems/shoryuken-d7d9a5624a89/bin/shoryuken:32:in 'Shoryuken::CLI::Runner#start': undefined method 'symbolize_keys' for an instance of Hash (NoMethodError)

        opts = options.to_h.symbolize_keys
                           ^^^^^^^^^^^^^^^
  from /usr/local/bundle/gems/thor-1.4.0/lib/thor/command.rb:28:in 'Thor::Command#run'
  from /usr/local/bundle/gems/thor-1.4.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
  from /usr/local/bundle/gems/thor-1.4.0/lib/thor.rb:538:in 'Thor.dispatch'
  from /usr/local/bundle/gems/thor-1.4.0/lib/thor/base.rb:584:in 'Thor::Base::ClassMethods#start'
  from /usr/local/bundle/bundler/gems/shoryuken-d7d9a5624a89/bin/shoryuken:54:in '<top (required)>'
  from ./bin/shoryuken:27:in 'Kernel#load'
  from ./bin/shoryuken:27:in '<main>'
exited with code 1
```

We do not have activesupport as an explicitly dependency. We do have activejob listed in the projects Gemfile so this error would not appear on gem development. Removing ActiveSupport code will ensure Shoryuken runs appropriately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of message attribute and configuration key handling during normalization, reducing errors when keys are non-string or use unexpected formats. This prevents intermittent issues accessing message attributes and stabilizes processing in edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->