### PR TITLE
Add yard-lint with comprehensive YARD documentation

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -1,0 +1,279 @@
+# YARD-Lint Configuration
+# See https://github.com/mensfeld/yard-lint for documentation
+
+# Global settings for all validators
+AllValidators:
+  YardOptions:
+  - "--private"
+  - "--protected"
+  Exclude:
+  - "\\.git"
+  - vendor/**/*
+  - node_modules/**/*
+  - spec/**/*
+  - test/**/*
+  - bin/**/*
+  - examples/**/*
+  - test_workers/**/*
+  FailOnSeverity: convention
+  MinCoverage: 100
+  DiffMode:
+    DefaultBaseRef:
+
+# Documentation validators
+Documentation/UndocumentedObjects:
+  Description: Checks for classes, modules, and methods without documentation.
+  Enabled: true
+  Severity: error
+  ExcludedMethods:
+  - initialize/0
+  - "/^_/"
+
+Documentation/UndocumentedMethodArguments:
+  Description: Checks for method parameters without @param tags.
+  Enabled: true
+  Severity: error
+
+Documentation/UndocumentedBooleanMethods:
+  Description: Checks that question mark methods document their boolean return.
+  Enabled: true
+  Severity: error
+
+Documentation/UndocumentedOptions:
+  Description: Detects methods with options hash parameters but no @option tags.
+  Enabled: true
+  Severity: error
+
+Documentation/MarkdownSyntax:
+  Description: Detects common markdown syntax errors in documentation.
+  Enabled: true
+  Severity: error
+
+Documentation/EmptyCommentLine:
+  Description: Detects empty comment lines at the start or end of documentation blocks.
+  Enabled: true
+  Severity: convention
+  EnabledPatterns:
+    Leading: true
+    Trailing: true
+
+Documentation/BlankLineBeforeDefinition:
+  Description: Detects blank lines between YARD documentation and method definition.
+  Enabled: true
+  Severity: convention
+  OrphanedSeverity: convention
+  EnabledPatterns:
+    SingleBlankLine: true
+    OrphanedDocs: true
+
+# Tags validators
+Tags/Order:
+  Description: Enforces consistent ordering of YARD tags.
+  Enabled: true
+  Severity: error
+  EnforcedOrder:
+  - param
+  - option
+  - return
+  - raise
+  - example
+
+Tags/InvalidTypes:
+  Description: Validates type definitions in @param, @return, @option tags.
+  Enabled: true
+  Severity: error
+  ValidatedTags:
+  - param
+  - option
+  - return
+
+Tags/TypeSyntax:
+  Description: Validates YARD type syntax using YARD parser.
+  Enabled: true
+  Severity: error
+  ValidatedTags:
+  - param
+  - option
+  - return
+  - yieldreturn
+
+Tags/MeaninglessTag:
+  Description: Detects @param/@option tags on classes, modules, or constants.
+  Enabled: true
+  Severity: error
+  CheckedTags:
+  - param
+  - option
+  InvalidObjectTypes:
+  - class
+  - module
+  - constant
+
+Tags/CollectionType:
+  Description: Validates Hash collection syntax consistency.
+  Enabled: true
+  Severity: error
+  EnforcedStyle: long
+  ValidatedTags:
+  - param
+  - option
+  - return
+  - yieldreturn
+
+Tags/TagTypePosition:
+  Description: Validates type annotation position in tags.
+  Enabled: true
+  Severity: error
+  CheckedTags:
+  - param
+  - option
+  EnforcedStyle: type_after_name
+
+Tags/ApiTags:
+  Description: Enforces @api tags on public objects.
+  Enabled: false
+  Severity: error
+  AllowedApis:
+  - public
+  - private
+  - internal
+
+Tags/OptionTags:
+  Description: Requires @option tags for methods with options parameters.
+  Enabled: true
+  Severity: error
+
+Tags/ExampleSyntax:
+  Description: Validates Ruby syntax in @example tags.
+  Enabled: true
+  Severity: warning
+
+Tags/RedundantParamDescription:
+  Description: Detects meaningless parameter descriptions that add no value.
+  Enabled: true
+  Severity: convention
+  CheckedTags:
+  - param
+  - option
+  Articles:
+  - The
+  - the
+  - A
+  - a
+  - An
+  - an
+  MaxRedundantWords: 6
+  GenericTerms:
+  - object
+  - instance
+  - value
+  - data
+  - item
+  - element
+  EnabledPatterns:
+    ArticleParam: true
+    PossessiveParam: true
+    TypeRestatement: true
+    ParamToVerb: true
+    IdPattern: true
+    DirectionalDate: true
+    TypeGeneric: true
+
+Tags/InformalNotation:
+  Description: Detects informal tag notation patterns like "Note:" instead of @note.
+  Enabled: true
+  Severity: warning
+  CaseSensitive: false
+  RequireStartOfLine: true
+  Patterns:
+    Note: "@note"
+    Todo: "@todo"
+    TODO: "@todo"
+    FIXME: "@todo"
+    See: "@see"
+    See also: "@see"
+    Warning: "@deprecated"
+    Deprecated: "@deprecated"
+    Author: "@author"
+    Version: "@version"
+    Since: "@since"
+    Returns: "@return"
+    Raises: "@raise"
+    Example: "@example"
+
+Tags/NonAsciiType:
+  Description: Detects non-ASCII characters in type annotations.
+  Enabled: true
+  Severity: warning
+  ValidatedTags:
+  - param
+  - option
+  - return
+  - yieldreturn
+  - yieldparam
+
+Tags/TagGroupSeparator:
+  Description: Enforces blank line separators between different YARD tag groups.
+  Enabled: false
+  Severity: convention
+  TagGroups:
+    param:
+    - param
+    - option
+    return:
+    - return
+    error:
+    - raise
+    - throws
+    example:
+    - example
+    meta:
+    - see
+    - note
+    - todo
+    - deprecated
+    - since
+    - version
+    - api
+    yield:
+    - yield
+    - yieldparam
+    - yieldreturn
+  RequireAfterDescription: false
+
+# Warnings validators - catches YARD parser errors
+Warnings/UnknownTag:
+  Description: Detects unknown YARD tags.
+  Enabled: true
+  Severity: error
+
+Warnings/UnknownDirective:
+  Description: Detects unknown YARD directives.
+  Enabled: true
+  Severity: error
+
+Warnings/InvalidTagFormat:
+  Description: Detects malformed tag syntax.
+  Enabled: true
+  Severity: error
+
+Warnings/InvalidDirectiveFormat:
+  Description: Detects malformed directive syntax.
+  Enabled: true
+  Severity: error
+
+Warnings/DuplicatedParameterName:
+  Description: Detects duplicate @param tags.
+  Enabled: true
+  Severity: error
+
+Warnings/UnknownParameterName:
+  Description: Detects @param tags for non-existent parameters.
+  Enabled: true
+  Severity: error
+
+# Semantic validators
+Semantic/AbstractMethods:
+  Description: Ensures @abstract methods do not have real implementations.
+  Enabled: true
+  Severity: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## [7.0.0] - Unreleased
+- Enhancement: Add yard-lint with comprehensive YARD documentation
+  - Adds yard-lint gem for documentation linting
+  - Documents all public classes, modules, and methods with YARD tags
+  - Ensures 100% documentation coverage
+
 - Enhancement: Add `enqueue_all` for bulk ActiveJob enqueuing (Rails 7.1+)
   - Implements efficient bulk enqueuing using SQS `send_message_batch` API
   - Called by `ActiveJob.perform_all_later` for batching multiple jobs

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'multi_xml'
   gem 'simplecov'
   gem 'warning'
+  gem 'yard-lint'
 end
 
 group :development do

--- a/bin/cli/base.rb
+++ b/bin/cli/base.rb
@@ -1,7 +1,14 @@
+# frozen_string_literal: true
+
 module Shoryuken
   module CLI
+    # Base class for CLI commands providing common helper methods.
     class Base < Thor
       no_commands do
+        # Prints entries as a formatted table
+        #
+        # @param entries [Array<Array>] rows to print as a table
+        # @return [void]
         def print_table(entries)
           column_sizes = print_columns_size(entries)
 
@@ -10,6 +17,10 @@ module Shoryuken
           end
         end
 
+        # Calculates the maximum width for each column
+        #
+        # @param entries [Array<Array>] the table rows
+        # @return [Hash<Integer, Integer>] column index to max width mapping
         def print_columns_size(entries)
           column_sizes = Hash.new(0)
 
@@ -23,11 +34,21 @@ module Shoryuken
           column_sizes
         end
 
+        # Formats a column value with padding
+        #
+        # @param column [Object] the column value to format
+        # @param size [Integer] the target width
+        # @return [String] the formatted column
         def print_format_column(column, size)
           size_with_padding = size + 4
           column.to_s.ljust(size_with_padding)
         end
 
+        # Outputs a failure message and optionally exits
+        #
+        # @param msg [String] the failure message
+        # @param quit [Boolean] whether to exit the program
+        # @return [void]
         def fail_task(msg, quit = true)
           say "[FAIL] #{msg}", :red
           exit(1) if quit

--- a/lib/active_job/extensions.rb
+++ b/lib/active_job/extensions.rb
@@ -9,6 +9,8 @@ module Shoryuken
       extend ActiveSupport::Concern
 
       included do
+        # @!attribute [rw] sqs_send_message_parameters
+        #   @return [Hash] the SQS send message parameters
         attr_accessor :sqs_send_message_parameters
       end
     end
@@ -17,12 +19,23 @@ module Shoryuken
     # to the empty hash, and populates it whenever `#enqueue` is called, such
     # as when using ActiveJob::Base.set.
     module SQSSendMessageParametersSupport
+      # Initializes a new ActiveJob instance with empty SQS parameters
+      #
+      # @param arguments [Array] the job arguments
       def initialize(*arguments)
         super(*arguments)
         self.sqs_send_message_parameters = {}
       end
       ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
+      # Enqueues the job with optional SQS-specific parameters
+      #
+      # @param options [Hash] enqueue options
+      # @option options [Hash] :message_attributes custom SQS message attributes
+      # @option options [Hash] :message_system_attributes system attributes
+      # @option options [String] :message_deduplication_id FIFO deduplication ID
+      # @option options [String] :message_group_id FIFO message group ID
+      # @return [Object] the enqueue result
       def enqueue(options = {})
         sqs_options = options.extract! :message_attributes,
                                        :message_system_attributes,

--- a/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
+++ b/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
@@ -6,33 +6,50 @@ require_relative 'shoryuken_adapter'
 
 module ActiveJob
   module QueueAdapters
-    # == Shoryuken concurrent adapter for Active Job
+    # Shoryuken concurrent adapter for Active Job.
     #
     # This adapter sends messages asynchronously (ie non-blocking) and allows
-    # the caller to set up handlers for both success and failure
+    # the caller to set up handlers for both success and failure.
     #
-    # To use this adapter, set up as:
+    # @example Setting up the adapter
+    #   success_handler = ->(response, job, options) { StatsD.increment("#{job.class.name}.success") }
+    #   error_handler = ->(err, job, options) { StatsD.increment("#{job.class.name}.failure") }
     #
-    # success_handler = ->(response, job, options) { StatsD.increment("#{job.class.name}.success") }
-    # error_handler = ->(err, job, options) { StatsD.increment("#{job.class.name}.failure") }
+    #   adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new(success_handler, error_handler)
     #
-    # adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new(success_handler, error_handler)
-    #
-    # config.active_job.queue_adapter = adapter
+    #   config.active_job.queue_adapter = adapter
     class ShoryukenConcurrentSendAdapter < ShoryukenAdapter
+      # Initializes a new concurrent send adapter
+      #
+      # @param success_handler [Proc, nil] callback for successful enqueues
+      # @param error_handler [Proc, nil] callback for failed enqueues
       def initialize(success_handler = nil, error_handler = nil)
         @success_handler = success_handler
         @error_handler = error_handler
       end
 
+      # Enqueues a job asynchronously
+      #
+      # @param job [ActiveJob::Base] the job to enqueue
+      # @param options [Hash] SQS message configuration
+      # @option options [Integer] :delay_seconds delay before the message becomes visible
+      # @option options [String] :message_group_id FIFO queue group ID
+      # @option options [String] :message_deduplication_id FIFO queue deduplication ID
+      # @return [Concurrent::Promises::Future] the future representing the async operation
       def enqueue(job, options = {})
         send_concurrently(job, options) { |f_job, f_options| super(f_job, f_options) }
       end
 
+      # Returns the success handler, using a default no-op if not set
+      #
+      # @return [Proc] the success handler
       def success_handler
         @success_handler ||= ->(_send_message_response, _job, _options) { nil }
       end
 
+      # Returns the error handler, using a default logger if not set
+      #
+      # @return [Proc] the error handler
       def error_handler
         @error_handler ||= lambda { |error, job, _options|
           Shoryuken.logger.warn("Failed to enqueue job: #{job.inspect} due to error: #{error}")
@@ -41,6 +58,14 @@ module ActiveJob
 
       private
 
+      # Sends a message concurrently using futures
+      #
+      # @param job [ActiveJob::Base] the job to enqueue
+      # @param options [Hash] SQS message configuration passed to the enqueue operation
+      # @option options [Integer] :delay_seconds delay before the message becomes visible
+      # @option options [String] :message_group_id FIFO queue group ID
+      # @yield [job, options] the actual enqueue operation
+      # @return [Concurrent::Promises::Future] the future representing the async operation
       def send_concurrently(job, options)
         Concurrent::Promises
           .future(job, options) { |f_job, f_options| [yield(f_job, f_options), f_job, f_options] }

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -14,6 +14,8 @@ loader = Zeitwerk::Loader.for_gem
 loader.ignore("#{__dir__}/active_job")
 loader.setup
 
+# Shoryuken is a super efficient AWS SQS thread based message processor.
+# It provides a simple interface to process SQS messages using Ruby workers.
 module Shoryuken
   extend SingleForwardable
 

--- a/lib/shoryuken/active_job/current_attributes.rb
+++ b/lib/shoryuken/active_job/current_attributes.rb
@@ -4,6 +4,7 @@ require 'active_support/current_attributes'
 require 'active_job'
 
 module Shoryuken
+  # ActiveJob integration module for Shoryuken
   module ActiveJob
     # Middleware to persist Rails CurrentAttributes across job execution.
     #
@@ -27,17 +28,25 @@ module Shoryuken
       module Serializer
         module_function
 
+        # Serializes attributes hash for SQS message storage
+        #
+        # @param attrs [Hash] the attributes to serialize
+        # @return [Object] the serialized attributes
         def serialize(attrs)
           ::ActiveJob::Arguments.serialize([attrs]).first
         end
 
+        # Deserializes attributes hash from SQS message
+        #
+        # @param attrs [Object] the serialized attributes
+        # @return [Hash] the deserialized attributes
         def deserialize(attrs)
           ::ActiveJob::Arguments.deserialize([attrs]).first
         end
       end
 
       class << self
-        # @return [Hash<String, String>] registered CurrentAttributes classes mapped to keys
+        # @return [Hash{String => String}] registered CurrentAttributes classes mapped to keys
         attr_reader :cattrs
 
         # Register CurrentAttributes classes to persist across job execution.
@@ -70,6 +79,11 @@ module Shoryuken
       module Persistence
         private
 
+        # Builds the SQS message with CurrentAttributes data
+        #
+        # @param queue [Shoryuken::Queue] the target queue
+        # @param job [ActiveJob::Base] the job being enqueued
+        # @return [Hash] the message parameters
         def message(queue, job)
           hash = super
 
@@ -89,6 +103,11 @@ module Shoryuken
 
       # Module prepended to JobWrapper to restore CurrentAttributes on execute.
       module Loading
+        # Performs the job after restoring CurrentAttributes
+        #
+        # @param sqs_msg [Shoryuken::Message] the SQS message
+        # @param hash [Hash] the deserialized job data
+        # @return [void]
         def perform(sqs_msg, hash)
           klasses_to_reset = []
 

--- a/lib/shoryuken/body_parser.rb
+++ b/lib/shoryuken/body_parser.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Parses SQS message bodies according to worker configuration.
+  # Supports JSON parsing, text extraction, custom Procs, and
+  # any object that responds to parse or load methods.
   class BodyParser
     class << self
+      # Parses the body of an SQS message according to the worker's body_parser option
+      #
+      # @param worker_class [Class] the worker class with shoryuken options
+      # @param sqs_msg [Shoryuken::Message] the SQS message to parse
+      # @return [Object] the parsed message body
       def parse(worker_class, sqs_msg)
         body_parser = worker_class.get_shoryuken_options['body_parser']
 

--- a/lib/shoryuken/client.rb
+++ b/lib/shoryuken/client.rb
@@ -1,18 +1,32 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Client class for interacting with SQS queues.
+  # Provides a simple interface for accessing and managing queue instances.
   class Client
+    # @return [Hash{String => Shoryuken::Queue}] cached queue instances by name
     @@queues = {}
 
     class << self
+      # Returns a Queue instance for the given queue name
+      #
+      # @param name [String, Symbol] the name of the queue
+      # @return [Shoryuken::Queue] the queue instance
       def queues(name)
         @@queues[name.to_s] ||= Shoryuken::Queue.new(sqs, name)
       end
 
+      # Returns the current SQS client
+      #
+      # @return [Aws::SQS::Client] the SQS client
       def sqs
         Shoryuken.sqs_client
       end
 
+      # Sets a new SQS client and clears the queue cache
+      #
+      # @param sqs [Aws::SQS::Client] the new SQS client
+      # @return [Aws::SQS::Client] the SQS client
       def sqs=(sqs)
         # Since the @@queues values (Shoryuken::Queue objects) are built referencing @@sqs, if it changes, we need to
         #   re-build them on subsequent calls to `.queues(name)`.

--- a/lib/shoryuken/default_exception_handler.rb
+++ b/lib/shoryuken/default_exception_handler.rb
@@ -1,9 +1,18 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Default exception handler that logs errors during message processing.
+  # Implements a simple error logging strategy that outputs the exception
+  # message and backtrace to the configured logger.
   class DefaultExceptionHandler
     extend Util
 
+    # Handles an exception that occurred during message processing
+    #
+    # @param exception [Exception] the exception that was raised
+    # @param _queue [String] the queue name where the error occurred (unused)
+    # @param _sqs_msg [Shoryuken::Message] the message being processed (unused)
+    # @return [void]
     def self.call(exception, _queue, _sqs_msg)
       logger.error { "Processor failed: #{exception.message}" }
       logger.error { exception.backtrace.join("\n") } if exception.backtrace

--- a/lib/shoryuken/default_worker_registry.rb
+++ b/lib/shoryuken/default_worker_registry.rb
@@ -1,19 +1,34 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Default implementation of the worker registry.
+  # Stores and retrieves worker classes mapped to queue names.
   class DefaultWorkerRegistry < WorkerRegistry
+    # Initializes a new DefaultWorkerRegistry with an empty workers hash
     def initialize
       @workers = Shoryuken::Helpers::AtomicHash.new
     end
 
+    # Checks if a queue is configured for batch message receiving
+    #
+    # @param queue [String] the queue name
+    # @return [Boolean] true if the queue's worker has batch mode enabled
     def batch_receive_messages?(queue)
       !!(@workers[queue] && @workers[queue].get_shoryuken_options['batch'])
     end
 
+    # Clears all registered workers
+    #
+    # @return [void]
     def clear
       @workers.clear
     end
 
+    # Fetches a worker instance for processing a message
+    #
+    # @param queue [String] the queue name
+    # @param message [Shoryuken::Message, Array<Shoryuken::Message>] the message or batch
+    # @return [Object, nil] a new worker instance or nil if not found
     def fetch_worker(queue, message)
       worker_class = !message.is_a?(Array) &&
                      message.message_attributes &&
@@ -29,10 +44,19 @@ module Shoryuken
       worker_class.new if worker_class
     end
 
+    # Returns all registered queue names
+    #
+    # @return [Array<String>] the queue names with registered workers
     def queues
       @workers.keys
     end
 
+    # Registers a worker class for a queue
+    #
+    # @param queue [String] the queue name
+    # @param clazz [Class] the worker class to register
+    # @return [Class] the registered worker class
+    # @raise [ArgumentError] if a batchable worker is already registered for the queue
     def register_worker(queue, clazz)
       if (worker_class = @workers[queue]) && (worker_class.get_shoryuken_options['batch'] == true || clazz.get_shoryuken_options['batch'] == true)
         fail ArgumentError, "Could not register #{clazz} for #{queue}, "\
@@ -43,6 +67,10 @@ module Shoryuken
       @workers[queue] = clazz
     end
 
+    # Returns all worker classes for a queue
+    #
+    # @param queue [String] the queue name
+    # @return [Array<Class>] the registered worker classes
     def workers(queue)
       [@workers.fetch(queue, [])].flatten
     end

--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -1,15 +1,26 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Fetches messages from SQS queues.
+  # Handles message retrieval with automatic retry on connectivity errors.
   class Fetcher
     include Util
 
+    # Maximum number of messages that can be fetched in a single SQS request
     FETCH_LIMIT = 10
 
+    # Initializes a new Fetcher for a processing group
+    #
+    # @param group [String] the processing group name
     def initialize(group)
       @group = group
     end
 
+    # Fetches messages from a queue with automatic retry
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @param limit [Integer] the maximum number of messages to fetch
+    # @return [Array<Aws::SQS::Types::Message>] the fetched messages
     def fetch(queue, limit)
       fetch_with_auto_retry(3) do
         started_at = Time.now
@@ -27,6 +38,11 @@ module Shoryuken
 
     private
 
+    # Fetches with automatic retry on errors
+    #
+    # @param max_attempts [Integer] maximum number of retry attempts
+    # @yield the fetch operation to retry
+    # @return [Object] the result of the block
     def fetch_with_auto_retry(max_attempts)
       attempts = 0
 
@@ -46,6 +62,11 @@ module Shoryuken
       end
     end
 
+    # Receives messages from an SQS queue
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @param limit [Integer] the maximum number of messages to receive
+    # @return [Array<Aws::SQS::Types::Message>, nil] the received messages
     def receive_messages(queue, limit)
       options = receive_options(queue)
 
@@ -60,6 +81,13 @@ module Shoryuken
       shoryuken_queue.receive_messages(options)
     end
 
+    # Determines the maximum number of messages to fetch
+    #
+    # @param shoryuken_queue [Shoryuken::Queue] the queue instance
+    # @param limit [Integer] the requested limit
+    # @param options [Hash] receive options that may contain max_number_of_messages
+    # @option options [Integer] :max_number_of_messages optional override for max messages
+    # @return [Integer] the maximum number of messages to fetch
     def max_number_of_messages(shoryuken_queue, limit, options)
       # For FIFO queues we want to make sure we process one message per group at a time
       # if we set max_number_of_messages greater than 1,
@@ -75,6 +103,10 @@ module Shoryuken
       [limit, FETCH_LIMIT, options[:max_number_of_messages]].compact.min
     end
 
+    # Returns the receive options for a queue
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @return [Hash] the receive options hash
     def receive_options(queue)
       options = Shoryuken.sqs_client_receive_message_opts[queue.name]
       options ||= Shoryuken.sqs_client_receive_message_opts[@group]
@@ -82,6 +114,10 @@ module Shoryuken
       options.to_h.dup
     end
 
+    # Checks if a queue uses batch message processing
+    #
+    # @param queue [Shoryuken::Queue] the queue to check
+    # @return [Boolean] true if the queue is configured for batch processing
     def batched_queue?(queue)
       Shoryuken.worker_registry.batch_receive_messages?(queue.name)
     end

--- a/lib/shoryuken/helpers/atomic_boolean.rb
+++ b/lib/shoryuken/helpers/atomic_boolean.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Helper classes providing thread-safe utilities and data structures
   module Helpers
     # A thread-safe boolean implementation using AtomicCounter as base.
     # Drop-in replacement for Concurrent::AtomicBoolean without external dependencies.
@@ -9,33 +10,46 @@ module Shoryuken
       # Prevent misuse of counter operations on a boolean
       undef_method :increment, :decrement
 
+      # Initializes a new AtomicBoolean
+      #
+      # @param initial_value [Boolean] the initial value
       def initialize(initial_value = false)
         super(initial_value ? 1 : 0)
       end
 
-      # Get the current value as boolean
+      # Gets the current value as a boolean
+      #
+      # @return [Boolean] the current value
       def value
         super != 0
       end
 
-      # Set the value to true
+      # Sets the value to true
+      #
+      # @return [Boolean] true
       def make_true
         @mutex.synchronize { @value = 1 }
         true
       end
 
-      # Set the value to false
+      # Sets the value to false
+      #
+      # @return [Boolean] false
       def make_false
         @mutex.synchronize { @value = 0 }
         false
       end
 
-      # Check if the value is true
+      # Checks if the value is true
+      #
+      # @return [Boolean] true if the value is true
       def true?
         @mutex.synchronize { @value != 0 }
       end
 
-      # Check if the value is false
+      # Checks if the value is false
+      #
+      # @return [Boolean] true if the value is false
       def false?
         @mutex.synchronize { @value == 0 }
       end

--- a/lib/shoryuken/helpers/timer_task.rb
+++ b/lib/shoryuken/helpers/timer_task.rb
@@ -5,6 +5,13 @@ module Shoryuken
     # A thread-safe timer task implementation.
     # Drop-in replacement for Concurrent::TimerTask without external dependencies.
     class TimerTask
+      # Initializes a new TimerTask
+      #
+      # @param execution_interval [Float] interval in seconds between task executions
+      # @param task [Proc] the task to execute on each interval (provided as a block)
+      # @return [TimerTask] a new TimerTask instance
+      # @raise [ArgumentError] if no block is provided or interval is not positive
+      # @yield the task to execute on each interval
       def initialize(execution_interval:, &task)
         raise ArgumentError, 'A block must be provided' unless block_given?
 
@@ -18,7 +25,9 @@ module Shoryuken
         @killed = false
       end
 
-      # Start the timer task execution
+      # Starts the timer task execution
+      #
+      # @return [TimerTask] self for method chaining
       def execute
         @mutex.synchronize do
           return self if @running || @killed
@@ -29,7 +38,9 @@ module Shoryuken
         self
       end
 
-      # Stop and kill the timer task
+      # Stops and kills the timer task
+      #
+      # @return [Boolean] true if killed, false if already killed
       def kill
         @mutex.synchronize do
           return false if @killed
@@ -44,6 +55,9 @@ module Shoryuken
 
       private
 
+      # Runs the timer loop in a separate thread
+      #
+      # @return [void]
       def run_timer_loop
         until @killed
           sleep(@execution_interval)

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Launches and coordinates Shoryuken's message processing managers.
+  # Handles the lifecycle of the processing system including startup, shutdown, and health checks.
   class Launcher
     include Util
 
+    # Initializes a new Launcher with managers for each processing group
     def initialize
       @managers = create_managers
       @stopping = false
@@ -20,6 +23,9 @@ module Shoryuken
       @stopping
     end
 
+    # Starts the message processing system
+    #
+    # @return [void]
     def start
       logger.info { 'Starting' }
 
@@ -27,6 +33,9 @@ module Shoryuken
       start_managers
     end
 
+    # Forces an immediate stop of all processing
+    #
+    # @return [void]
     def stop!
       @stopping = true
       initiate_stop
@@ -40,6 +49,9 @@ module Shoryuken
       fire_event(:stopped)
     end
 
+    # Gracefully stops all processing, waiting for in-flight messages
+    #
+    # @return [void]
     def stop
       @stopping = true
       fire_event(:quiet, true)
@@ -55,6 +67,9 @@ module Shoryuken
       fire_event(:stopped)
     end
 
+    # Checks if all processing groups are healthy
+    #
+    # @return [Boolean] true if all groups are running normally
     def healthy?
       Shoryuken.groups.keys.all? do |group|
         manager = @managers.find { |m| m.group == group }
@@ -64,30 +79,48 @@ module Shoryuken
 
     private
 
+    # Stops all managers from dispatching new messages
+    #
+    # @return [void]
     def stop_new_dispatching
       @managers.each(&:stop_new_dispatching)
     end
 
+    # Waits for any in-progress dispatching to complete
+    #
+    # @return [void]
     def await_dispatching_in_progress
       @managers.each(&:await_dispatching_in_progress)
     end
 
+    # Returns the executor for running async operations
+    #
+    # @return [Concurrent::ExecutorService] the executor service
     def executor
       @_executor ||= Shoryuken.launcher_executor || Concurrent.global_io_executor
     end
 
+    # Starts all managers in parallel futures
+    #
+    # @return [void]
     def start_managers
       @managers.each do |manager|
         Concurrent::Future.execute { manager.start }
       end
     end
 
+    # Initiates the stop sequence
+    #
+    # @return [void]
     def initiate_stop
       logger.info { 'Shutting down' }
 
       stop_callback
     end
 
+    # Executes the start callback and fires startup event
+    #
+    # @return [void]
     def start_callback
       if (callback = Shoryuken.start_callback)
         logger.debug { 'Calling start_callback' }
@@ -97,6 +130,9 @@ module Shoryuken
       fire_event(:startup)
     end
 
+    # Executes the stop callback and fires shutdown event
+    #
+    # @return [void]
     def stop_callback
       if (callback = Shoryuken.stop_callback)
         logger.debug { 'Calling stop_callback' }
@@ -106,6 +142,9 @@ module Shoryuken
       fire_event(:shutdown, true)
     end
 
+    # Creates managers for each configured processing group
+    #
+    # @return [Array<Shoryuken::Manager>] the created managers
     def create_managers
       Shoryuken.groups.map do |group, options|
         Shoryuken::Manager.new(

--- a/lib/shoryuken/logging.rb
+++ b/lib/shoryuken/logging.rb
@@ -7,8 +7,14 @@ require_relative 'logging/pretty'
 require_relative 'logging/without_timestamp'
 
 module Shoryuken
+  # Provides logging functionality for Shoryuken.
+  # Manages the global logger instance and thread-local context.
   module Logging
-
+    # Executes a block with a thread-local logging context
+    #
+    # @param msg [String] the context message to set
+    # @yield the block to execute within the context
+    # @return [Object] the result of the block
     def self.with_context(msg)
       Thread.current[:shoryuken_context] = msg
       yield
@@ -16,6 +22,10 @@ module Shoryuken
       Thread.current[:shoryuken_context] = nil
     end
 
+    # Initializes a new logger instance
+    #
+    # @param log_target [IO, String] the logging target (file path or IO object)
+    # @return [Logger] the initialized logger
     def self.initialize_logger(log_target = STDOUT)
       @logger = Logger.new(log_target)
       @logger.level = Logger::INFO
@@ -23,10 +33,17 @@ module Shoryuken
       @logger
     end
 
+    # Returns the current logger instance, initializing if needed
+    #
+    # @return [Logger] the logger instance
     def self.logger
       @logger ||= initialize_logger
     end
 
+    # Sets the logger instance
+    #
+    # @param log [Logger, nil] the logger to use, or nil for null logger
+    # @return [Logger] the logger instance
     def self.logger=(log)
       @logger = log || Logger.new('/dev/null')
     end

--- a/lib/shoryuken/logging/pretty.rb
+++ b/lib/shoryuken/logging/pretty.rb
@@ -8,7 +8,7 @@ module Shoryuken
     # Output format: "TIMESTAMP PID TID-THREAD_ID CONTEXT SEVERITY: MESSAGE"
     #
     # @example Output
-    #   2023-08-15T10:30:45Z 12345 TID-abc123 MyWorker/queue1/msg-456 INFO: Processing message
+    #   "2023-08-15T10:30:45Z 12345 TID-abc123 MyWorker/queue1/msg-456 INFO: Processing message"
     class Pretty < Base
       # Formats a log message with timestamp and full context information.
       #

--- a/lib/shoryuken/logging/without_timestamp.rb
+++ b/lib/shoryuken/logging/without_timestamp.rb
@@ -8,7 +8,7 @@ module Shoryuken
     # Output format: "pid=PID tid=THREAD_ID CONTEXT SEVERITY: MESSAGE"
     #
     # @example Output
-    #   pid=12345 tid=abc123 MyWorker/queue1/msg-456 INFO: Processing message
+    #   "pid=12345 tid=abc123 MyWorker/queue1/msg-456 INFO: Processing message"
     class WithoutTimestamp < Base
       # Formats a log message without timestamp information.
       #

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -1,15 +1,28 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Manages message dispatching and processing for a single processing group.
+  # Coordinates between the fetcher, polling strategy, and processor.
   class Manager
     include Util
 
+    # Maximum number of messages to fetch in a single batch request
     BATCH_LIMIT = 10
-    # See https://github.com/ruby-shoryuken/shoryuken/issues/348#issuecomment-292847028
+
+    # Minimum interval between dispatch cycles
+    # @see https://github.com/ruby-shoryuken/shoryuken/issues/348#issuecomment-292847028
     MIN_DISPATCH_INTERVAL = 0.1
 
+    # @return [String] the processing group name
     attr_reader :group
 
+    # Initializes a new Manager for a processing group
+    #
+    # @param group [String] the processing group name
+    # @param fetcher [Shoryuken::Fetcher] the message fetcher
+    # @param polling_strategy [Shoryuken::Polling::BaseStrategy] the polling strategy
+    # @param concurrency [Integer] the maximum number of concurrent processors
+    # @param executor [Concurrent::ExecutorService] the executor for async operations
     def initialize(group, fetcher, polling_strategy, concurrency, executor)
       @group                      = group
       @fetcher                    = fetcher
@@ -22,15 +35,24 @@ module Shoryuken
       @dispatching_release_signal = ::Queue.new
     end
 
+    # Starts the dispatch loop
+    #
+    # @return [void]
     def start
       fire_utilization_update_event
       dispatch_loop
     end
 
+    # Signals the manager to stop dispatching new messages
+    #
+    # @return [void]
     def stop_new_dispatching
       @stop_new_dispatching.make_true
     end
 
+    # Waits for any in-progress dispatching to complete
+    #
+    # @return [void]
     def await_dispatching_in_progress
       # There might still be a dispatching on-going, as the response from SQS could take some time
       # We don't want to stop the process before processing incoming messages, as they would stay "in-flight" for some time on SQS
@@ -38,12 +60,18 @@ module Shoryuken
       @dispatching_release_signal.pop
     end
 
+    # Checks if the manager is still running
+    #
+    # @return [Boolean] true if the manager is running
     def running?
       @running.true? && @executor.running?
     end
 
     private
 
+    # The main dispatch loop
+    #
+    # @return [void]
     def dispatch_loop
       if @stop_new_dispatching.true? || !running?
         @dispatching_release_signal << 1
@@ -53,6 +81,9 @@ module Shoryuken
       @executor.post { dispatch }
     end
 
+    # Dispatches messages from a queue
+    #
+    # @return [void]
     def dispatch
       return unless running?
 
@@ -71,14 +102,24 @@ module Shoryuken
       dispatch_loop
     end
 
+    # Returns the count of busy processors
+    #
+    # @return [Integer] the number of busy processors
     def busy
       @busy_processors.value
     end
 
+    # Returns the count of ready processors
+    #
+    # @return [Integer] the number of available processors
     def ready
       @max_processors - busy
     end
 
+    # Handles completion of processor work
+    #
+    # @param queue [String] the queue name
+    # @return [void]
     def processor_done(queue)
       @busy_processors.decrement
       fire_utilization_update_event
@@ -90,6 +131,11 @@ module Shoryuken
       @polling_strategy.message_processed(queue)
     end
 
+    # Assigns a message to a processor
+    #
+    # @param queue_name [String] the queue name
+    # @param sqs_msg [Aws::SQS::Types::Message, Array<Aws::SQS::Types::Message>] the message or batch
+    # @return [Concurrent::Promise, nil] the processing promise or nil if not running
     def assign(queue_name, sqs_msg)
       return unless running?
 
@@ -112,22 +158,38 @@ module Shoryuken
         .rescue { processor_done(queue_name) }
     end
 
+    # Dispatches a batch of messages from a queue
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @return [void]
     def dispatch_batch(queue)
       batch = @fetcher.fetch(queue, BATCH_LIMIT)
       @polling_strategy.messages_found(queue.name, batch.size)
       assign(queue.name, patch_batch!(batch)) if batch.any?
     end
 
+    # Dispatches individual messages from a queue
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @return [void]
     def dispatch_single_messages(queue)
       messages = @fetcher.fetch(queue, ready)
       @polling_strategy.messages_found(queue.name, messages.size)
       messages.each { |message| assign(queue.name, message) }
     end
 
+    # Checks if a queue uses batch message processing
+    #
+    # @param queue [Shoryuken::Polling::QueueConfiguration] the queue configuration
+    # @return [Boolean] true if the queue is configured for batch processing
     def batched_queue?(queue)
       Shoryuken.worker_registry.batch_receive_messages?(queue.name)
     end
 
+    # Patches a batch array with a message_id method
+    #
+    # @param sqs_msgs [Array<Aws::SQS::Types::Message>] the batch of messages
+    # @return [Array<Aws::SQS::Types::Message>] the patched batch
     def patch_batch!(sqs_msgs)
       sqs_msgs.instance_eval do
         def message_id
@@ -138,6 +200,10 @@ module Shoryuken
       sqs_msgs
     end
 
+    # Handles errors during dispatch
+    #
+    # @param ex [Exception] the exception that occurred
+    # @return [void]
     def handle_dispatch_error(ex)
       logger.error { "Manager failed: #{ex.message}" }
       logger.error { ex.backtrace.join("\n") } unless ex.backtrace.nil?
@@ -147,6 +213,9 @@ module Shoryuken
       @running.make_false
     end
 
+    # Fires a utilization update event
+    #
+    # @return [void]
     def fire_utilization_update_event
       fire_event :utilization_update, false, {
         group: @group,

--- a/lib/shoryuken/middleware/chain.rb
+++ b/lib/shoryuken/middleware/chain.rb
@@ -199,8 +199,10 @@ module Shoryuken
       # Each middleware's call method will be invoked in sequence,
       # with control passed through yielding.
       #
-      # @param args [Array] Arguments to pass to each middleware
-      # @yield The final action to perform after all middleware
+      # @param args [Array] arguments to pass to each middleware
+      # @param final_action [Proc] the final action to perform after all middleware (provided as a block)
+      # @return [void]
+      # @yield the final action to perform after all middleware
       def invoke(*args, &final_action)
         chain = retrieve.dup
         traverse_chain = lambda do

--- a/lib/shoryuken/middleware/server/active_record.rb
+++ b/lib/shoryuken/middleware/server/active_record.rb
@@ -2,8 +2,16 @@
 
 module Shoryuken
   module Middleware
+    # Server-side middleware that runs around message processing
     module Server
+      # Middleware that clears ActiveRecord connections after message processing.
+      # Ensures database connections are returned to the pool after each job.
       class ActiveRecord
+        # Processes a message and clears database connections afterwards
+        #
+        # @param _args [Array] middleware call arguments (unused)
+        # @yield continues to the next middleware in the chain
+        # @return [void]
         def call(*_args)
           yield
         ensure

--- a/lib/shoryuken/middleware/server/auto_delete.rb
+++ b/lib/shoryuken/middleware/server/auto_delete.rb
@@ -3,7 +3,17 @@
 module Shoryuken
   module Middleware
     module Server
+      # Middleware that automatically deletes messages after successful processing.
+      # Only deletes messages when the worker has auto_delete enabled.
       class AutoDelete
+        # Processes a message and deletes it if auto_delete is enabled
+        #
+        # @param worker [Object] the worker instance
+        # @param queue [String] the queue name
+        # @param sqs_msg [Shoryuken::Message, Array<Shoryuken::Message>] the message or batch
+        # @param _body [Object] the parsed message body (unused)
+        # @yield continues to the next middleware in the chain
+        # @return [void]
         def call(worker, queue, sqs_msg, _body)
           yield
 

--- a/lib/shoryuken/middleware/server/auto_extend_visibility.rb
+++ b/lib/shoryuken/middleware/server/auto_extend_visibility.rb
@@ -3,11 +3,22 @@
 module Shoryuken
   module Middleware
     module Server
+      # Middleware that automatically extends message visibility timeout during processing.
+      # Prevents messages from becoming visible to other consumers while still being processed.
       class AutoExtendVisibility
         include Util
 
+        # Number of seconds before timeout to extend visibility
         EXTEND_UPFRONT_SECONDS = 5
 
+        # Processes a message with automatic visibility timeout extension
+        #
+        # @param worker [Object] the worker instance
+        # @param queue [String] the queue name
+        # @param sqs_msg [Shoryuken::Message, Array<Shoryuken::Message>] the message or batch
+        # @param body [Object] the parsed message body
+        # @yield continues to the next middleware in the chain
+        # @return [void]
         def call(worker, queue, sqs_msg, body)
           return yield unless worker.class.auto_visibility_timeout?
 
@@ -24,9 +35,17 @@ module Shoryuken
 
         private
 
+        # Helper class for extending message visibility
         class MessageVisibilityExtender
           include Util
 
+          # Creates a timer task that extends message visibility
+          #
+          # @param _worker [Object] the worker instance (unused)
+          # @param queue [String] the queue name
+          # @param sqs_msg [Shoryuken::Message] the message
+          # @param _body [Object] the parsed message body (unused)
+          # @return [Shoryuken::Helpers::TimerTask] the timer task
           def auto_extend(_worker, queue, sqs_msg, _body)
             queue_visibility_timeout = Shoryuken::Client.queues(queue).visibility_timeout
 
@@ -44,6 +63,13 @@ module Shoryuken
           end
         end
 
+        # Creates and starts a visibility extension timer
+        #
+        # @param worker [Object] the worker instance
+        # @param queue [String] the queue name
+        # @param sqs_msg [Shoryuken::Message] the message
+        # @param body [Object] the parsed message body
+        # @return [Shoryuken::Helpers::TimerTask] the started timer
         def auto_visibility_timer(worker, queue, sqs_msg, body)
           MessageVisibilityExtender.new.auto_extend(worker, queue, sqs_msg, body).tap(&:execute)
         end

--- a/lib/shoryuken/middleware/server/timing.rb
+++ b/lib/shoryuken/middleware/server/timing.rb
@@ -3,9 +3,20 @@
 module Shoryuken
   module Middleware
     module Server
+      # Middleware that logs timing information for message processing.
+      # Records start time, completion time, and warns if processing
+      # exceeds the queue's visibility timeout.
       class Timing
         include Util
 
+        # Processes a message while logging timing information
+        #
+        # @param _worker [Object] the worker instance (unused)
+        # @param queue [String] the queue name
+        # @param _sqs_msg [Shoryuken::Message] the message being processed (unused)
+        # @param _body [Object] the parsed message body (unused)
+        # @yield continues to the next middleware in the chain
+        # @return [void]
         def call(_worker, queue, _sqs_msg, _body)
           started_at = Time.now
 

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Stores and manages all Shoryuken configuration options.
+  # This class is used internally to hold settings for workers, queues,
+  # middleware, and other runtime configurations.
   class Options
+    # Default configuration values for Shoryuken
     DEFAULTS = {
       thread_priority: -1,
       concurrency: 25,
@@ -19,14 +23,46 @@ module Shoryuken
       }
     }.freeze
 
+    # @!attribute [rw] active_job_queue_name_prefixing
+    #   @return [Boolean] whether to enable ActiveJob queue name prefixing
+    # @!attribute [rw] cache_visibility_timeout
+    #   @return [Boolean] whether to cache SQS visibility timeout
+    # @!attribute [rw] groups
+    #   @return [Hash{String => Hash}] the configured processing groups
+    # @!attribute [rw] launcher_executor
+    #   @return [Object] the executor used to launch workers
+    # @!attribute [rw] reloader
+    #   @return [Proc] the code reloader proc for development environments
+    # @!attribute [rw] enable_reloading
+    #   @return [Boolean] whether code reloading is enabled
+    # @!attribute [rw] start_callback
+    #   @return [Proc, nil] callback to execute when server starts
+    # @!attribute [rw] stop_callback
+    #   @return [Proc, nil] callback to execute when server stops
+    # @!attribute [rw] worker_executor
+    #   @return [Class] the executor class for running workers
+    # @!attribute [rw] worker_registry
+    #   @return [Shoryuken::WorkerRegistry] the registry for worker classes
+    # @!attribute [rw] exception_handlers
+    #   @return [Array<#call>] handlers for processing exceptions
     attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout,
                   :groups, :launcher_executor, :reloader, :enable_reloading,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry,
                   :exception_handlers
 
+    # @!attribute [w] default_worker_options
+    #   @return [Hash] the default options for workers
+    # @!attribute [w] sqs_client
+    #   @return [Aws::SQS::Client] the SQS client instance
+    # @!attribute [w] logger
+    #   @return [Logger] the logger instance
     attr_writer :default_worker_options, :sqs_client, :logger
+
+    # @!attribute [r] sqs_client_receive_message_opts
+    #   @return [Hash] options passed to SQS receive_message calls
     attr_reader :sqs_client_receive_message_opts
 
+    # Initializes a new Options instance with default values
     def initialize
       self.groups = {}
       self.worker_registry = DefaultWorkerRegistry.new
@@ -40,10 +76,19 @@ module Shoryuken
       @sqs_client_receive_message_opts ||= {}
     end
 
+    # Checks if ActiveJob is available
+    #
+    # @return [Boolean] true if ActiveJob is defined
     def active_job?
       defined?(::ActiveJob)
     end
 
+    # Adds a processing group with the specified concurrency and delay
+    #
+    # @param group [String] the name of the group
+    # @param concurrency [Integer, nil] the number of concurrent workers for the group
+    # @param delay [Float, nil] the delay between polling cycles
+    # @return [Hash] the group configuration
     def add_group(group, concurrency = nil, delay: nil)
       concurrency ||= options[:concurrency]
       delay ||= options[:delay]
@@ -55,16 +100,29 @@ module Shoryuken
       }
     end
 
+    # Adds a queue to a processing group with the specified weight
+    #
+    # @param queue [String] the name of the queue
+    # @param weight [Integer] the weight (priority) of the queue
+    # @param group [String] the name of the group to add the queue to
+    # @return [void]
     def add_queue(queue, weight, group)
       weight.times do
         groups[group][:queues] << queue
       end
     end
 
+    # Returns all queues from all groups
+    #
+    # @return [Array<String>] flat array of all queue names
     def ungrouped_queues
       groups.values.flat_map { |options| options[:queues] }
     end
 
+    # Returns the polling strategy class for a group
+    #
+    # @param group [String] the name of the group
+    # @return [Class] the polling strategy class to use
     def polling_strategy(group)
       strategy = (group == 'default' ? options : options[:groups].to_h[group]).to_h[:polling_strategy]
       case strategy
@@ -83,54 +141,103 @@ module Shoryuken
       end
     end
 
+    # Returns the polling delay for a group
+    #
+    # @param group [String] the name of the group
+    # @return [Float] the delay in seconds
     def delay(group)
       groups[group].to_h.fetch(:delay, options[:delay]).to_f
     end
 
+    # Returns the SQS client, initializing a default one if needed
+    #
+    # @return [Aws::SQS::Client] the SQS client
     def sqs_client
       @sqs_client ||= Aws::SQS::Client.new
     end
 
+    # Sets the SQS client receive message options for the default group
+    #
+    # @param sqs_client_receive_message_opts [Hash] the options hash
+    # @return [Hash] the options hash
     def sqs_client_receive_message_opts=(sqs_client_receive_message_opts)
       @sqs_client_receive_message_opts['default'] = sqs_client_receive_message_opts
     end
 
+    # Returns the global options hash
+    #
+    # @return [Hash] the options hash
     def options
       @options ||= DEFAULTS.dup
     end
 
+    # Returns the logger instance
+    #
+    # @return [Logger] the logger
     def logger
       @logger ||= Shoryuken::Logging.logger
     end
 
+    # Returns the thread priority setting
+    #
+    # @return [Integer] the thread priority
     def thread_priority
       @thread_priority ||= options[:thread_priority]
     end
 
+    # Sets the thread priority
+    #
+    # @param value [Integer] the thread priority value
+    # @return [Integer] the thread priority
+    attr_writer :thread_priority
+
+    # Registers a worker class with the worker registry
+    #
+    # @param args [Array] arguments to pass to the registry
+    # @return [void]
     def register_worker(*args)
       worker_registry.register_worker(*args)
     end
 
+    # Yields self if running as a server for server-specific configuration
+    #
+    # @yield [Shoryuken::Options] the options instance
+    # @return [void]
     def configure_server
       yield self if server?
     end
 
+    # Returns the server middleware chain
+    #
+    # @yield [Shoryuken::Middleware::Chain] the middleware chain for configuration
+    # @return [Shoryuken::Middleware::Chain] the server middleware chain
     def server_middleware
       @_server_chain ||= default_server_middleware
       yield @_server_chain if block_given?
       @_server_chain
     end
 
+    # Yields self unless running as a server for client-specific configuration
+    #
+    # @yield [Shoryuken::Options] the options instance
+    # @return [void]
     def configure_client
       yield self unless server?
     end
 
+    # Returns the client middleware chain
+    #
+    # @yield [Shoryuken::Middleware::Chain] the middleware chain for configuration
+    # @return [Shoryuken::Middleware::Chain] the client middleware chain
     def client_middleware
       @_client_chain ||= default_client_middleware
       yield @_client_chain if block_given?
       @_client_chain
     end
 
+    # Returns the default worker options hash
+    #
+    # @return [Hash{String => Object}] the default worker options
     def default_worker_options
       @default_worker_options ||= {
         'queue' => 'default',
@@ -142,17 +249,32 @@ module Shoryuken
       }
     end
 
+    # Registers a callback to run when the server starts
+    #
+    # @param block [Proc] the block to execute on start
+    # @return [void]
+    # @yield the block to execute on start
     def on_start(&block)
       self.start_callback = block
     end
 
+    # Registers a callback to run when the server stops
+    #
+    # @param block [Proc] the block to execute on stop
+    # @return [void]
+    # @yield the block to execute on stop
     def on_stop(&block)
       self.stop_callback = block
     end
 
-    # Register a block to run at a point in the Shoryuken lifecycle.
-    # :startup, :quiet, :shutdown or :stopped are valid events.
+    # Registers a block to run at a point in the Shoryuken lifecycle.
     #
+    # @param event [Symbol] the lifecycle event (:startup, :quiet, :shutdown, or :stopped)
+    # @param block [Proc] the block to execute for the event
+    # @return [void]
+    # @raise [ArgumentError] if event is not a Symbol or not a valid event name
+    # @yield the block to execute for the event
+    # @example
     #   Shoryuken.configure_server do |config|
     #     config.on(:shutdown) do
     #       puts "Goodbye cruel world!"
@@ -165,20 +287,32 @@ module Shoryuken
       options[:lifecycle_events][event] << block
     end
 
+    # Checks if running as a server (CLI mode)
+    #
+    # @return [Boolean] true if Shoryuken::CLI is defined
     def server?
       defined?(Shoryuken::CLI)
     end
 
+    # Checks if visibility timeout caching is enabled
+    #
+    # @return [Boolean] true if caching is enabled
     def cache_visibility_timeout?
       @cache_visibility_timeout
     end
 
+    # Checks if ActiveJob queue name prefixing is enabled
+    #
+    # @return [Boolean] true if prefixing is enabled
     def active_job_queue_name_prefixing?
       @active_job_queue_name_prefixing
     end
 
     private
 
+    # Creates the default server middleware chain
+    #
+    # @return [Shoryuken::Middleware::Chain] the default middleware chain
     def default_server_middleware
       Middleware::Chain.new do |m|
         m.add Middleware::Server::Timing
@@ -192,6 +326,9 @@ module Shoryuken
       end
     end
 
+    # Creates the default client middleware chain
+    #
+    # @return [Shoryuken::Middleware::Chain] an empty middleware chain
     def default_client_middleware
       Middleware::Chain.new
     end

--- a/lib/shoryuken/polling/base_strategy.rb
+++ b/lib/shoryuken/polling/base_strategy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Polling strategies for determining which queue to fetch messages from next
   module Polling
     # Abstract base class for queue polling strategies.
     #

--- a/lib/shoryuken/polling/weighted_round_robin.rb
+++ b/lib/shoryuken/polling/weighted_round_robin.rb
@@ -2,7 +2,14 @@
 
 module Shoryuken
   module Polling
+    # A polling strategy that processes queues in weighted round-robin order.
+    # Queue weights determine how often each queue is polled relative to others.
+    # Queues are temporarily paused when no messages are found.
     class WeightedRoundRobin < BaseStrategy
+      # Initializes a new WeightedRoundRobin polling strategy
+      #
+      # @param queues [Array<String>] array of queue names, with weights indicated by repetition
+      # @param delay [Float, nil] delay in seconds before unpausing empty queues
       def initialize(queues, delay = nil)
         @initial_queues = queues
         @queues = queues.dup.uniq
@@ -10,6 +17,9 @@ module Shoryuken
         @delay = delay
       end
 
+      # Returns the next queue to poll in round-robin order
+      #
+      # @return [QueueConfiguration, nil] the next queue configuration or nil if all paused
       def next_queue
         unpause_queues
         queue = @queues.shift
@@ -19,6 +29,11 @@ module Shoryuken
         QueueConfiguration.new(queue, {})
       end
 
+      # Handles the result of polling a queue, adjusting weight if messages were found
+      #
+      # @param queue [String] the queue name
+      # @param messages_found [Integer] number of messages found
+      # @return [void]
       def messages_found(queue, messages_found)
         if messages_found == 0
           pause(queue)
@@ -33,10 +48,17 @@ module Shoryuken
         end
       end
 
+      # Returns the list of active queues with their current weights
+      #
+      # @return [Array<Array>] array of [queue_name, weight] pairs
       def active_queues
         unparse_queues(@queues)
       end
 
+      # Called when a message from a queue has been processed
+      #
+      # @param queue [String] the queue name
+      # @return [void]
       def message_processed(queue)
         paused_queue = @paused_queues.find { |_time, name| name == queue }
         return unless paused_queue
@@ -46,6 +68,10 @@ module Shoryuken
 
       private
 
+      # Pauses a queue by removing it from active rotation
+      #
+      # @param queue [String] the queue name to pause
+      # @return [void]
       def pause(queue)
         return unless @queues.delete(queue)
 
@@ -53,6 +79,9 @@ module Shoryuken
         logger.debug "Paused #{queue}"
       end
 
+      # Unpauses queues whose delay has expired
+      #
+      # @return [void]
       def unpause_queues
         return if @paused_queues.empty?
         return if Time.now < @paused_queues.first[0]
@@ -62,14 +91,27 @@ module Shoryuken
         logger.debug "Unpaused #{pause[1]}"
       end
 
+      # Returns the current weight of a queue in the active rotation
+      #
+      # @param queue [String] the queue name
+      # @return [Integer] the current weight
       def current_queue_weight(queue)
         queue_weight(@queues, queue)
       end
 
+      # Returns the maximum configured weight of a queue
+      #
+      # @param queue [String] the queue name
+      # @return [Integer] the maximum weight
       def maximum_queue_weight(queue)
         queue_weight(@initial_queues, queue)
       end
 
+      # Counts how many times a queue appears in the given array
+      #
+      # @param queues [Array<String>] the array to count in
+      # @param queue [String] the queue name to count
+      # @return [Integer] the count
       def queue_weight(queues, queue)
         queues.count { |q| q == queue }
       end

--- a/lib/shoryuken/processor.rb
+++ b/lib/shoryuken/processor.rb
@@ -1,20 +1,38 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Processes SQS messages by invoking the appropriate worker.
+  # Handles middleware chain execution and exception handling.
   class Processor
     include Util
 
-    attr_reader :queue, :sqs_msg
+    # @return [String] the queue name
+    attr_reader :queue
 
+    # @return [Aws::SQS::Types::Message, Array<Aws::SQS::Types::Message>] the message or batch
+    attr_reader :sqs_msg
+
+    # Processes a message from a queue
+    #
+    # @param queue [String] the queue name
+    # @param sqs_msg [Aws::SQS::Types::Message, Array<Aws::SQS::Types::Message>] the message or batch
+    # @return [Object] the result of the worker's perform method
     def self.process(queue, sqs_msg)
       new(queue, sqs_msg).process
     end
 
+    # Initializes a new Processor
+    #
+    # @param queue [String] the queue name
+    # @param sqs_msg [Aws::SQS::Types::Message, Array<Aws::SQS::Types::Message>] the message or batch
     def initialize(queue, sqs_msg)
       @queue   = queue
       @sqs_msg = sqs_msg
     end
 
+    # Processes the message through the middleware chain and worker
+    #
+    # @return [Object] the result of the worker's perform method
     def process
       worker_perform = proc do
         return logger.error { "No worker found for #{queue}" } unless worker
@@ -41,18 +59,31 @@ module Shoryuken
 
     private
 
+    # Fetches the worker instance for processing
+    #
+    # @return [Object, nil] the worker instance or nil if not found
     def worker
       @_worker ||= Shoryuken.worker_registry.fetch_worker(queue, sqs_msg)
     end
 
+    # Returns the worker class
+    #
+    # @return [Class] the worker class
     def worker_class
       worker.class
     end
 
+    # Parses the message body or bodies for batch processing
+    #
+    # @return [Object, Array<Object>] the parsed body or array of bodies
     def body
       @_body ||= sqs_msg.is_a?(Array) ? sqs_msg.map(&method(:parse_body)) : parse_body(sqs_msg)
     end
 
+    # Parses a single message body
+    #
+    # @param sqs_msg [Aws::SQS::Types::Message] the message to parse
+    # @return [Object] the parsed message body
     def parse_body(sqs_msg)
       BodyParser.parse(worker_class, sqs_msg)
     end

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -1,20 +1,41 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Represents an SQS queue and provides methods for sending and receiving messages.
+  # Handles both standard and FIFO queues, automatically adding required FIFO attributes.
   class Queue
     include Util
 
+    # SQS attribute name for FIFO queue identification
     FIFO_ATTR               = 'FifoQueue'
+
+    # Default message group ID used for FIFO queues
     MESSAGE_GROUP_ID        = 'ShoryukenMessage'
+
+    # SQS attribute name for visibility timeout
     VISIBILITY_TIMEOUT_ATTR = 'VisibilityTimeout'
 
-    attr_accessor :name, :client, :url
+    # @return [String] the queue name
+    attr_accessor :name
 
+    # @return [Aws::SQS::Client] the SQS client
+    attr_accessor :client
+
+    # @return [String] the queue URL
+    attr_accessor :url
+
+    # Initializes a new Queue instance
+    #
+    # @param client [Aws::SQS::Client] the SQS client
+    # @param name_or_url_or_arn [String] the queue name, URL, or ARN
     def initialize(client, name_or_url_or_arn)
       self.client = client
       set_name_and_url(name_or_url_or_arn)
     end
 
+    # Returns the visibility timeout for the queue
+    #
+    # @return [Integer] the visibility timeout in seconds
     def visibility_timeout
       # Always lookup for the latest visibility when cache is disabled
       # setting it to nil, forces re-lookup
@@ -22,6 +43,11 @@ module Shoryuken
       @_visibility_timeout ||= queue_attributes.attributes[VISIBILITY_TIMEOUT_ATTR].to_i
     end
 
+    # Deletes messages from the queue in batch
+    #
+    # @param options [Hash] options for delete_message_batch
+    # @option options [Array<Hash>] :entries entries to delete with id and receipt_handle
+    # @return [Boolean] true if any messages failed to delete
     def delete_messages(options)
       failed_messages = client.delete_message_batch(
         options.merge(queue_url: url)
@@ -33,6 +59,15 @@ module Shoryuken
       end
     end
 
+    # Sends a single message to the queue
+    #
+    # @param options [Hash, String] message options or message body string
+    # @option options [String] :message_body the message body
+    # @option options [Integer] :delay_seconds delay before message becomes visible
+    # @option options [Hash] :message_attributes custom message attributes
+    # @option options [String] :message_group_id FIFO queue message group ID
+    # @option options [String] :message_deduplication_id FIFO queue deduplication ID
+    # @return [Aws::SQS::Types::SendMessageResult] the send result
     def send_message(options)
       options = sanitize_message!(options).merge(queue_url: url)
 
@@ -41,15 +76,32 @@ module Shoryuken
       end
     end
 
+    # Sends multiple messages to the queue in batch
+    #
+    # @param options [Hash, Array] batch options or array of message bodies/hashes
+    # @option options [Array<Hash>] :entries message entries to send
+    # @return [Aws::SQS::Types::SendMessageBatchResult] the batch send result
     def send_messages(options)
       client.send_message_batch(sanitize_messages!(options).merge(queue_url: url))
     end
 
+    # Receives messages from the queue
+    #
+    # @param options [Hash] options for receive_message
+    # @option options [Integer] :max_number_of_messages maximum messages to receive
+    # @option options [Integer] :visibility_timeout visibility timeout for received messages
+    # @option options [Integer] :wait_time_seconds long polling wait time
+    # @option options [Array<String>] :attribute_names SQS attributes to retrieve
+    # @option options [Array<String>] :message_attribute_names message attributes to retrieve
+    # @return [Array<Shoryuken::Message>] the received messages
     def receive_messages(options)
       messages = client.receive_message(options.merge(queue_url: url)).messages || []
       messages.map { |m| Message.new(client, self, m) }
     end
 
+    # Checks if the queue is a FIFO queue
+    #
+    # @return [Boolean] true if the queue is a FIFO queue
     def fifo?
       # Make sure the memoization work with boolean to avoid multiple calls to SQS
       # see https://github.com/ruby-shoryuken/shoryuken/pull/529
@@ -61,21 +113,36 @@ module Shoryuken
 
     private
 
+    # Initializes the FIFO attribute by calling fifo?
+    #
+    # @return [Boolean] whether the queue is FIFO
     def initialize_fifo_attribute
       # calling fifo? will also initialize it
       fifo?
     end
 
+    # Sets the queue name and URL from a queue name
+    #
+    # @param name [String] the queue name
+    # @return [void]
     def set_by_name(name) # rubocop:disable Naming/AccessorMethodName
       self.name = name
       self.url  = client.get_queue_url(queue_name: name).queue_url
     end
 
+    # Sets the queue name and URL from a queue URL
+    #
+    # @param url [String] the queue URL
+    # @return [void]
     def set_by_url(url) # rubocop:disable Naming/AccessorMethodName
       self.name = url.split('/').last
       self.url  = url
     end
 
+    # Converts an ARN to a queue URL
+    #
+    # @param arn_str [String] the ARN string
+    # @return [String] the queue URL
     def arn_to_url(arn_str)
       *, region, account_id, resource = arn_str.split(':')
 
@@ -87,6 +154,10 @@ module Shoryuken
       "https://sqs.#{region}.amazonaws.com/#{account_id}/#{resource}"
     end
 
+    # Sets the queue name and URL from a name, URL, or ARN
+    #
+    # @param name_or_url_or_arn [String] the queue identifier
+    # @return [void]
     def set_name_and_url(name_or_url_or_arn) # rubocop:disable Naming/AccessorMethodName
       if name_or_url_or_arn.include?('://')
         set_by_url(name_or_url_or_arn)
@@ -110,12 +181,20 @@ module Shoryuken
       raise e, "The specified queue #{name_or_url_or_arn} does not exist."
     end
 
+    # Returns the queue attributes from SQS
+    #
+    # @return [Aws::SQS::Types::GetQueueAttributesResult] the queue attributes
     def queue_attributes
       # Note: Retrieving all queue attributes as requesting `FifoQueue` on non-FIFO queue raises error.
       # See issue: https://github.com/aws/aws-sdk-ruby/issues/1350
       client.get_queue_attributes(queue_url: url, attribute_names: ['All'])
     end
 
+    # Sanitizes a batch of messages, converting to proper format
+    #
+    # @param options [Hash, Array] batch options or array of messages
+    # @option options [Array<Hash>] :entries message entries
+    # @return [Hash] the sanitized options with entries key
     def sanitize_messages!(options)
       if options.is_a?(Array)
         entries = options.map.with_index do |m, index|
@@ -130,6 +209,11 @@ module Shoryuken
       options
     end
 
+    # Adds FIFO attributes to message options if needed
+    #
+    # @param options [Hash] the message options
+    # @option options [String] :message_body the message body
+    # @return [Hash] the options with FIFO attributes added
     def add_fifo_attributes!(options)
       return unless fifo?
 
@@ -139,6 +223,11 @@ module Shoryuken
       options
     end
 
+    # Sanitizes a single message, converting body to JSON if needed
+    #
+    # @param options [Hash, String] message options or body string
+    # @option options [String, Hash] :message_body the message body
+    # @return [Hash] the sanitized message options
     def sanitize_message!(options)
       options = { message_body: options } if options.is_a?(String)
 

--- a/lib/shoryuken/runner.rb
+++ b/lib/shoryuken/runner.rb
@@ -9,9 +9,12 @@ require 'erb'
 require 'shoryuken'
 
 module Shoryuken
-  # See: https://github.com/mperham/sidekiq/blob/33f5d6b2b6c0dfaab11e5d39688cab7ebadc83ae/lib/sidekiq/cli.rb#L20
+  # Exception raised to trigger shutdown
+  # @see https://github.com/mperham/sidekiq/blob/33f5d6b2b6c0dfaab11e5d39688cab7ebadc83ae/lib/sidekiq/cli.rb#L20
   class Shutdown < Interrupt; end
 
+  # Runs the Shoryuken server process.
+  # Handles signal trapping, daemonization, and lifecycle management.
   class Runner
     include Util
     include Singleton
@@ -19,6 +22,14 @@ module Shoryuken
     # @return [Shoryuken::Launcher, nil] the launcher instance, or nil if not yet initialized
     attr_reader :launcher
 
+    # Runs the Shoryuken server with the given options
+    #
+    # @param options [Hash] runtime configuration options
+    # @option options [Boolean] :daemon whether to daemonize the process
+    # @option options [String] :pidfile path to the PID file
+    # @option options [String] :logfile path to the log file
+    # @option options [String] :config_file path to the configuration file
+    # @return [void]
     def run(options)
       self_read, self_write = IO.pipe
 
@@ -54,12 +65,18 @@ module Shoryuken
       end
     end
 
+    # Checks if the server is healthy
+    #
+    # @return [Boolean] true if the launcher is running and healthy
     def healthy?
       (@launcher && @launcher.healthy?) || false
     end
 
     private
 
+    # Initializes the Concurrent Ruby logger
+    #
+    # @return [void]
     def initialize_concurrent_logger
       return unless Shoryuken.logger
 
@@ -68,6 +85,12 @@ module Shoryuken
       end
     end
 
+    # Daemonizes the process
+    #
+    # @param options [Hash] options containing daemon and logfile settings
+    # @option options [Boolean] :daemon whether to daemonize
+    # @option options [String] :logfile path to the log file for daemon output
+    # @return [void]
     def daemonize(options)
       return unless options[:daemon]
 
@@ -93,12 +116,20 @@ module Shoryuken
       $stdin.reopen('/dev/null')
     end
 
+    # Writes the process ID to a file
+    #
+    # @param options [Hash] options containing the pidfile path
+    # @option options [String] :pidfile path to write the PID file
+    # @return [void]
     def write_pid(options)
       return unless (path = options[:pidfile])
 
       File.open(path, 'w') { |f| f.puts(Process.pid) }
     end
 
+    # Executes a soft shutdown on USR1 signal
+    #
+    # @return [void]
     def execute_soft_shutdown
       logger.info { 'Received USR1, will soft shutdown down' }
 
@@ -106,12 +137,18 @@ module Shoryuken
       exit 0
     end
 
+    # Executes a terminal stop on TSTP signal
+    #
+    # @return [void]
     def execute_terminal_stop
       logger.info { 'Received TSTP, will stop accepting new work' }
 
       @launcher.stop
     end
 
+    # Prints backtraces of all threads
+    #
+    # @return [void]
     def print_threads_backtrace
       Thread.list.each do |thread|
         logger.info { "Thread TID-#{thread.object_id.to_s(36)} #{thread['label']}" }
@@ -123,6 +160,11 @@ module Shoryuken
       end
     end
 
+    # Handles incoming signals
+    #
+    # @param sig [String] the signal name
+    # @return [void]
+    # @raise [Interrupt] on TERM or INT signals
     def handle_signal(sig)
       logger.debug "Got #{sig} signal"
 

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -1,11 +1,22 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Utility methods shared across Shoryuken classes.
+  # Provides logging, event firing, and helper methods.
   module Util
+    # Returns the Shoryuken logger
+    #
+    # @return [Logger] the configured logger
     def logger
       Shoryuken.logger
     end
 
+    # Fires a lifecycle event to all registered handlers
+    #
+    # @param event [Symbol] the event name to fire
+    # @param reverse [Boolean] whether to call handlers in reverse order
+    # @param event_options [Hash] options to pass to event handlers
+    # @return [void]
     def fire_event(event, reverse = false, event_options = {})
       logger.debug { "Firing '#{event}' lifecycle event" }
       arr = Shoryuken.options[:lifecycle_events][event]
@@ -18,17 +29,31 @@ module Shoryuken
       end
     end
 
+    # Calculates elapsed time in milliseconds
+    #
+    # @param started_at [Time] the start time
+    # @return [Float] elapsed time in milliseconds
     def elapsed(started_at)
       # elapsed in ms
       (Time.now - started_at) * 1000
     end
 
+    # Converts a queue array to a hash of queue names and weights
+    #
+    # @param queues [Array<String>] array of queue names with possible duplicates
+    # @return [Array<Array>] array of [queue_name, weight] pairs
     def unparse_queues(queues)
       queues.each_with_object({}) do |name, queue_and_weights|
         queue_and_weights[name] = queue_and_weights[name].to_i + 1
       end.to_a
     end
 
+    # Returns a display name for the worker processing a message
+    #
+    # @param worker_class [Class] the worker class
+    # @param sqs_msg [Aws::SQS::Types::Message, Array] the message or batch
+    # @param body [Object, nil] the parsed message body
+    # @return [String] the worker display name
     def worker_name(worker_class, sqs_msg, body = nil)
       if Shoryuken.active_job? \
           && !sqs_msg.is_a?(Array) \

--- a/lib/shoryuken/version.rb
+++ b/lib/shoryuken/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Current version of the Shoryuken gem
   VERSION = '7.0.0.rc1'
 end

--- a/lib/shoryuken/worker/inline_executor.rb
+++ b/lib/shoryuken/worker/inline_executor.rb
@@ -2,8 +2,18 @@
 
 module Shoryuken
   module Worker
+    # Executor that processes jobs synchronously in the current thread.
+    # Useful for testing and development environments.
     class InlineExecutor
       class << self
+        # Processes a job synchronously in the current thread
+        #
+        # @param worker_class [Class] the worker class that will process the message
+        # @param body [Object] the message body
+        # @param options [Hash] inline execution options
+        # @option options [String] :queue override the default queue name
+        # @option options [Hash] :message_attributes custom message attributes
+        # @return [Object] the result of the worker's perform method
         def perform_async(worker_class, body, options = {})
           body = JSON.dump(body) if body.is_a?(Hash)
           queue_name = options.delete(:queue) || worker_class.get_shoryuken_options['queue']
@@ -28,12 +38,26 @@ module Shoryuken
           call(worker_class, sqs_msg)
         end
 
+        # Processes a job synchronously, ignoring the delay interval
+        #
+        # @param worker_class [Class] the worker class that will process the message
+        # @param _interval [Integer, Float] ignored for inline execution
+        # @param body [Object] the message body
+        # @param options [Hash] inline execution options
+        # @option options [String] :queue override the default queue name
+        # @option options [Hash] :message_attributes custom message attributes
+        # @return [Object] the result of the worker's perform method
         def perform_in(worker_class, _interval, body, options = {})
           worker_class.perform_async(body, options)
         end
 
         private
 
+        # Instantiates and calls the worker
+        #
+        # @param worker_class [Class] the worker class
+        # @param sqs_msg [Shoryuken::InlineMessage] the message
+        # @return [Object] the result of the worker's perform method
         def call(worker_class, sqs_msg)
           parsed_body = BodyParser.parse(worker_class, sqs_msg)
           batch = worker_class.shoryuken_options_hash['batch']

--- a/lib/shoryuken/worker_registry.rb
+++ b/lib/shoryuken/worker_registry.rb
@@ -1,33 +1,66 @@
 # frozen_string_literal: true
 
 module Shoryuken
+  # Abstract base class for worker registries.
+  # Defines the interface for storing and retrieving worker classes.
+  # @abstract Subclass and implement all methods to create a custom registry
   class WorkerRegistry
+    # Checks if the workers for a queue support batch message processing
+    #
+    # @param _queue [String] the queue name
+    # @return [Boolean] true if batch processing is supported
+    # @raise [NotImplementedError] if not implemented by subclass
     def batch_receive_messages?(_queue)
       # true if the workers for queue support batch processing of messages
       fail NotImplementedError
     end
 
+    # Removes all worker registrations
+    #
+    # @return [void]
+    # @raise [NotImplementedError] if not implemented by subclass
     def clear
       # must remove all worker registrations
       fail NotImplementedError
     end
 
+    # Fetches a worker instance for processing a message
+    #
+    # @param _queue [String] the queue name
+    # @param _message [Shoryuken::Message, Array<Shoryuken::Message>] the message or batch
+    # @return [Object] a worker instance
+    # @raise [NotImplementedError] if not implemented by subclass
     def fetch_worker(_queue, _message)
       # must return an instance of the worker that handles
       # message received on queue
       fail NotImplementedError
     end
 
+    # Returns a list of all queues with registered workers
+    #
+    # @return [Array<String>] the queue names
+    # @raise [NotImplementedError] if not implemented by subclass
     def queues
       # must return a list of all queues with registered workers
       fail NotImplementedError
     end
 
+    # Registers a worker class for a queue
+    #
+    # @param _queue [String] the queue name
+    # @param _clazz [Class] the worker class
+    # @return [void]
+    # @raise [NotImplementedError] if not implemented by subclass
     def register_worker(_queue, _clazz)
       # must register the worker as a consumer of messages from queue
       fail NotImplementedError
     end
 
+    # Returns all worker classes registered for a queue
+    #
+    # @param _queue [String] the queue name
+    # @return [Array<Class>] the worker classes, or empty array
+    # @raise [NotImplementedError] if not implemented by subclass
     def workers(_queue)
       # must return the list of workers registered for queue, or []
       fail NotImplementedError


### PR DESCRIPTION
- Add yard-lint gem and configuration based on karafka/waterdrop
- Add YARD documentation to all public classes, modules, and methods
- Document module namespaces, class variables, and attributes
- Add @param, @return, @option, @yield, @raise, and @example tags
- Fix tag ordering to comply with yard-lint requirements
- Use proper YARD type syntax (Hash{Key => Value} format)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk job enqueuing for ActiveJob (Rails 7.1+) with SQS batch optimization
  * ActiveJob Continuations support (Rails 8.1+) with graceful shutdown handling
  * CurrentAttributes persistence across job enqueue/execution
  * Concurrent job sending with configurable success/error handlers
  * Enhanced CLI with queue management and table output
  * Lifecycle events (on_start, on_stop) for extensibility
  * Improved polling strategies (StrictPriority, WeightedRoundRobin)
  * Documentation linting enforcement via YARD-Lint

* **Breaking Changes**
  * Ruby 3.1 support dropped; now requires 3.2+
  * Rails versions prior to 7.2 no longer supported
  * Removed core Ruby extensions; use helper utilities instead

* **Improvements**
  * AWS message batch payload limit increased to 1MB
  * Enhanced signal handling and process management
  * Automatic message visibility timeout caching

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->