### PR TITLE
Address PR #909 review comments for YARD documentation

### DIFF
--- a/lib/active_job/extensions.rb
+++ b/lib/active_job/extensions.rb
@@ -9,8 +9,7 @@ module Shoryuken
       extend ActiveSupport::Concern
 
       included do
-        # @!attribute [rw] sqs_send_message_parameters
-        #   @return [Hash] the SQS send message parameters
+        # @return [Hash] the SQS send message parameters
         attr_accessor :sqs_send_message_parameters
       end
     end
@@ -26,7 +25,6 @@ module Shoryuken
         super(*arguments)
         self.sqs_send_message_parameters = {}
       end
-      ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
 
       # Enqueues the job with optional SQS-specific parameters
       #

--- a/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
+++ b/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
@@ -24,6 +24,7 @@ module ActiveJob
       # @param success_handler [Proc, nil] callback for successful enqueues
       # @param error_handler [Proc, nil] callback for failed enqueues
       def initialize(success_handler = nil, error_handler = nil)
+        super() if defined?(super)
         @success_handler = success_handler
         @error_handler = error_handler
       end

--- a/lib/shoryuken/active_job/current_attributes.rb
+++ b/lib/shoryuken/active_job/current_attributes.rb
@@ -46,7 +46,7 @@ module Shoryuken
       end
 
       class << self
-        # @return [Hash{String => String}] registered CurrentAttributes classes mapped to keys
+        # @return [Hash{String => String}] serialization keys mapped to CurrentAttributes class names
         attr_reader :cattrs
 
         # Register CurrentAttributes classes to persist across job execution.

--- a/lib/shoryuken/logging/pretty.rb
+++ b/lib/shoryuken/logging/pretty.rb
@@ -7,8 +7,8 @@ module Shoryuken
     #
     # Output format: "TIMESTAMP PID TID-THREAD_ID CONTEXT SEVERITY: MESSAGE"
     #
-    # @example Output
-    #   "2023-08-15T10:30:45Z 12345 TID-abc123 MyWorker/queue1/msg-456 INFO: Processing message"
+    # @example Sample output
+    #   # 2023-08-15T10:30:45Z 12345 TID-abc123 MyWorker/queue1/msg-456 INFO: Processing message
     class Pretty < Base
       # Formats a log message with timestamp and full context information.
       #

--- a/lib/shoryuken/logging/without_timestamp.rb
+++ b/lib/shoryuken/logging/without_timestamp.rb
@@ -7,8 +7,8 @@ module Shoryuken
     #
     # Output format: "pid=PID tid=THREAD_ID CONTEXT SEVERITY: MESSAGE"
     #
-    # @example Output
-    #   "pid=12345 tid=abc123 MyWorker/queue1/msg-456 INFO: Processing message"
+    # @example Sample output
+    #   # pid=12345 tid=abc123 MyWorker/queue1/msg-456 INFO: Processing message
     class WithoutTimestamp < Base
       # Formats a log message without timestamp information.
       #

--- a/lib/shoryuken/middleware/chain.rb
+++ b/lib/shoryuken/middleware/chain.rb
@@ -200,9 +200,8 @@ module Shoryuken
       # with control passed through yielding.
       #
       # @param args [Array] arguments to pass to each middleware
-      # @param final_action [Proc] the final action to perform after all middleware (provided as a block)
+      # @param final_action [Proc] the final action to perform after all middleware
       # @return [void]
-      # @yield the final action to perform after all middleware
       def invoke(*args, &final_action)
         chain = retrieve.dup
         traverse_chain = lambda do

--- a/lib/shoryuken/middleware/server/active_record.rb
+++ b/lib/shoryuken/middleware/server/active_record.rb
@@ -9,9 +9,9 @@ module Shoryuken
       class ActiveRecord
         # Processes a message and clears database connections afterwards
         #
-        # @param _args [Array] middleware call arguments (unused)
+        # @param _args [Array<Object>] middleware call arguments (unused)
         # @yield continues to the next middleware in the chain
-        # @return [void]
+        # @return [Object] return value from the next middleware or worker in the chain
         def call(*_args)
           yield
         ensure

--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -17,6 +17,8 @@ module Shoryuken
         # @param _body [Object] the parsed message body (unused)
         # @yield continues to the next middleware in the chain
         # @return [void]
+        # @raise [StandardError] re-raises the original exception if retry intervals are not configured
+        #   or if retry limit is exceeded
         def call(worker, _queue, sqs_msg, _body)
           return yield unless worker.class.exponential_backoff?
 

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -23,43 +23,28 @@ module Shoryuken
       }
     }.freeze
 
-    # @!attribute [rw] active_job_queue_name_prefixing
-    #   @return [Boolean] whether to enable ActiveJob queue name prefixing
-    # @!attribute [rw] cache_visibility_timeout
-    #   @return [Boolean] whether to cache SQS visibility timeout
-    # @!attribute [rw] groups
-    #   @return [Hash{String => Hash}] the configured processing groups
-    # @!attribute [rw] launcher_executor
-    #   @return [Object] the executor used to launch workers
-    # @!attribute [rw] reloader
-    #   @return [Proc] the code reloader proc for development environments
-    # @!attribute [rw] enable_reloading
-    #   @return [Boolean] whether code reloading is enabled
-    # @!attribute [rw] start_callback
-    #   @return [Proc, nil] callback to execute when server starts
-    # @!attribute [rw] stop_callback
-    #   @return [Proc, nil] callback to execute when server stops
-    # @!attribute [rw] worker_executor
-    #   @return [Class] the executor class for running workers
-    # @!attribute [rw] worker_registry
-    #   @return [Shoryuken::WorkerRegistry] the registry for worker classes
-    # @!attribute [rw] exception_handlers
-    #   @return [Array<#call>] handlers for processing exceptions
+    # @return [Boolean] whether to enable ActiveJob queue name prefixing
+    # @return [Boolean] whether to cache SQS visibility timeout
+    # @return [Hash{String => Hash}] the configured processing groups
+    # @return [Object] the executor used to launch workers
+    # @return [Proc] the code reloader proc for development environments
+    # @return [Boolean] whether code reloading is enabled
+    # @return [Proc, nil] callback to execute when server starts
+    # @return [Proc, nil] callback to execute when server stops
+    # @return [Class] the executor class for running workers
+    # @return [Shoryuken::WorkerRegistry] the registry for worker classes
+    # @return [Array<#call>] handlers for processing exceptions
     attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout,
                   :groups, :launcher_executor, :reloader, :enable_reloading,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry,
                   :exception_handlers
 
-    # @!attribute [w] default_worker_options
-    #   @return [Hash] the default options for workers
-    # @!attribute [w] sqs_client
-    #   @return [Aws::SQS::Client] the SQS client instance
-    # @!attribute [w] logger
-    #   @return [Logger] the logger instance
+    # @return [Hash] the default options for workers
+    # @return [Aws::SQS::Client] the SQS client instance
+    # @return [Logger] the logger instance
     attr_writer :default_worker_options, :sqs_client, :logger
 
-    # @!attribute [r] sqs_client_receive_message_opts
-    #   @return [Hash] options passed to SQS receive_message calls
+    # @return [Hash] options passed to SQS receive_message calls
     attr_reader :sqs_client_receive_message_opts
 
     # Initializes a new Options instance with default values

--- a/lib/shoryuken/runner.rb
+++ b/lib/shoryuken/runner.rb
@@ -131,7 +131,7 @@ module Shoryuken
     #
     # @return [void]
     def execute_soft_shutdown
-      logger.info { 'Received USR1, will soft shutdown down' }
+      logger.info { 'Received USR1, will soft shutdown' }
 
       @launcher.stop
       exit 0


### PR DESCRIPTION
## Summary
This PR addresses the review comments from PR #909 (yard-lint documentation).

### Changes made:
- **Fix typo in runner.rb**: `'will soft shutdown down'` → `'will soft shutdown'`
- **Fix @example tags**: Properly format example tags in logging formatters to use valid YARD syntax
- **Remove @!attribute directives**: Use standard YARD `@return` comments for `attr_accessor` declarations instead of `@!attribute` directives
- **Add @raise tag**: Document exception re-raising behavior in exponential_backoff_retry.rb
- **Fix @return type**: Change `void` to `Object` in active_record middleware since it returns the yielded value
- **Remove ruby2_keywords**: Remove obsolete `ruby2_keywords(:initialize)` call (Ruby 3.2+ minimum now)
- **Add super() call**: Add `super() if defined?(super)` in concurrent_send_adapter.rb for Rails 7.2+ compatibility
- **Update cattrs annotation**: Clarify that hash maps serialization keys to CurrentAttributes class names

## Test plan
- [x] yard-lint passes with no offenses
- [x] RSpec tests pass (473 examples, 0 failures)
- [x] Integration tests pass (34/34 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation and examples across middleware components and logging modules for clarity.
  * Improved parameter and return type annotations in middleware documentation.

* **Chores**
  * Refined log message wording during soft shutdown operations.
  * Internal code maintenance and documentation standardization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->