### PR TITLE
Add GitHub Action to sync wiki to public repo

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,42 @@
+name: Sync Wiki
+
+on:
+  gollum:  # Triggers when the hidden wiki is edited via GitHub UI
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  sync-to-public:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout hidden wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ruby-shoryuken/shoryuken.wiki
+          path: hidden-wiki
+
+      - name: Checkout public wiki
+        uses: actions/checkout@v4
+        with:
+          repository: ruby-shoryuken/wiki
+          path: public-wiki
+          token: ${{ secrets.WIKI_SYNC_TOKEN }}
+
+      - name: Sync wikis
+        run: |
+          # Copy all files from hidden wiki to public wiki (excluding .git)
+          rsync -av --delete hidden-wiki/ public-wiki/ --exclude .git
+
+          cd public-wiki
+
+          # Check if there are changes
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to sync"
+            exit 0
+          fi
+
+          # Configure git and commit
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Sync from shoryuken.wiki"
+          git push


### PR DESCRIPTION
## Summary

Adds a GitHub Action workflow to keep the public wiki repository (`ruby-shoryuken/wiki`) in sync with the hidden wiki (`shoryuken.wiki`).

## How it works

**Hidden wiki → Public wiki** (this PR):
- Triggers on `gollum` event (when wiki is edited via GitHub UI)
- Can also be triggered manually via `workflow_dispatch`
- Copies all files from hidden wiki to public wiki repo

**Public wiki → Hidden wiki** (in ruby-shoryuken/wiki repo):
- Triggers on push to `main` branch
- Syncs merged PRs back to the hidden wiki

## Setup required

You need to create a `WIKI_SYNC_TOKEN` secret in both repos:
1. Create a Personal Access Token (PAT) with `repo` scope
2. Add it as a secret named `WIKI_SYNC_TOKEN` in:
   - `ruby-shoryuken/shoryuken` (Settings → Secrets → Actions)
   - `ruby-shoryuken/wiki` (Settings → Secrets → Actions)

## Benefits

- PRs can be made against `ruby-shoryuken/wiki` for wiki changes
- Changes made via GitHub wiki UI are synced to public repo
- Both wikis stay in sync automatically