### PR TITLE
Fix PORO setup not loading AWS config from options

### DIFF
--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -134,11 +134,12 @@ module Shoryuken
       groups[group].to_h.fetch(:delay, options[:delay]).to_f
     end
 
-    # Returns the SQS client, initializing a default one if needed
+    # Returns the SQS client, initializing a default one if needed.
+    # Uses AWS configuration from options[:aws] if available.
     #
     # @return [Aws::SQS::Client] the SQS client
     def sqs_client
-      @sqs_client ||= Aws::SQS::Client.new
+      @sqs_client ||= Aws::SQS::Client.new(options[:aws])
     end
 
     # Sets the SQS client receive message options for the default group

--- a/spec/integration/aws_config/aws_config_spec.rb
+++ b/spec/integration/aws_config/aws_config_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# This spec tests that AWS configuration from Shoryuken.options[:aws]
+# is properly passed to the SQS client initialization.
+# This verifies the fix for issue #815: PORO setup does not load AWS config
+
+# Reset any cached SQS client to ensure fresh initialization
+Shoryuken.sqs_client = nil
+
+# Configure AWS options programmatically (simulating PORO setup with config file)
+Shoryuken.options[:aws] = {
+  region: 'us-east-1',
+  endpoint: 'http://localhost:4566',
+  access_key_id: 'test-key-from-config',
+  secret_access_key: 'test-secret-from-config'
+}
+
+# Get the SQS client - this should use the AWS config from options
+client = Shoryuken.sqs_client
+
+# Verify the client was configured with our options
+config = client.config
+
+assert_equal('us-east-1', config.region, "Region should be set from options[:aws]")
+assert_equal('http://localhost:4566', config.endpoint.to_s, "Endpoint should be set from options[:aws]")
+
+# Verify the client actually works by creating a queue
+queue_name = "aws-config-test-#{SecureRandom.hex(6)}"
+
+begin
+  result = client.create_queue(queue_name: queue_name)
+  assert(result.queue_url.include?(queue_name), "Should be able to create queue with configured client")
+
+  # Clean up
+  client.delete_queue(queue_url: result.queue_url)
+rescue Aws::SQS::Errors::ServiceError => e
+  raise "SQS client should work with configured AWS options: #{e.message}"
+end
+
+# Test 2: Verify that reconfiguring options and resetting client works
+Shoryuken.sqs_client = nil
+Shoryuken.options[:aws][:region] = 'us-west-2'
+
+client2 = Shoryuken.sqs_client
+assert_equal('us-west-2', client2.config.region, "New client should use updated region")
+
+# Test 3: Verify that credentials from options are used
+# Reset and reconfigure with explicit credentials
+Shoryuken.sqs_client = nil
+Shoryuken.options[:aws] = {
+  region: 'us-east-1',
+  endpoint: 'http://localhost:4566',
+  access_key_id: 'another-key',
+  secret_access_key: 'another-secret'
+}
+
+client3 = Shoryuken.sqs_client
+assert(client3.is_a?(Aws::SQS::Client), "Client should be created with new credentials")
+assert_equal('us-east-1', client3.config.region, "Region should match configured value")


### PR DESCRIPTION
## Summary
Fixes a bug where AWS configuration from `shoryuken.yml` (or programmatically set via `Shoryuken.options[:aws]`) was loaded but never passed to the SQS client initialization.

## Problem
The `sqs_client` method in `options.rb` was calling `Aws::SQS::Client.new` without any arguments:
```ruby
def sqs_client
  @sqs_client ||= Aws::SQS::Client.new
end
```

This meant that PORO (non-Rails) setups that relied on `shoryuken.yml` for AWS configuration would fail because the configuration was ignored.

## Solution
Pass the AWS options to the client:
```ruby
def sqs_client
  @sqs_client ||= Aws::SQS::Client.new(options[:aws])
end
```

## Test plan
- [x] Added integration spec `spec/integration/aws_config/aws_config_spec.rb`
- [x] All 473 unit specs pass
- [x] All 36 integration specs pass

Closes #815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS SQS client now respects AWS configuration settings (region, endpoint, credentials) from Shoryuken options.

* **Tests**
  * Added integration test to verify AWS configuration is properly applied to the SQS client.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->