### PR TITLE
Add body_parser integration specs

### DIFF
--- a/spec/integration/body_parser/json_parser_spec.rb
+++ b/spec/integration/body_parser/json_parser_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# This spec tests the body_parser option with :json setting
+# Verifies that JSON messages are automatically parsed into Ruby hashes
+
+setup_localstack
+
+queue_name = DT.uuid
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options body_parser: :json
+
+  def perform(sqs_msg, body)
+    DT[:parsed_bodies] << body
+    DT[:body_classes] << body.class.name
+  end
+end
+
+worker_class.get_shoryuken_options['queue'] = queue_name
+worker_class.get_shoryuken_options['auto_delete'] = true
+Shoryuken.register_worker(queue_name, worker_class)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a JSON message
+json_body = { 'name' => 'test', 'value' => 42, 'nested' => { 'key' => 'val' } }
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: JSON.dump(json_body)
+)
+
+sleep 1
+
+poll_queues_until { DT[:parsed_bodies].size >= 1 }
+
+assert_equal(1, DT[:parsed_bodies].size)
+assert_equal('Hash', DT[:body_classes].first)
+assert_equal('test', DT[:parsed_bodies].first['name'])
+assert_equal(42, DT[:parsed_bodies].first['value'])
+assert_equal('val', DT[:parsed_bodies].first['nested']['key'])

--- a/spec/integration/body_parser/proc_parser_spec.rb
+++ b/spec/integration/body_parser/proc_parser_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# This spec tests the body_parser option with a custom Proc
+# Verifies that custom parsing logic can be applied to messages
+
+setup_localstack
+
+queue_name = DT.uuid
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Custom parser that uppercases the body and adds metadata
+custom_parser = proc do |sqs_msg|
+  {
+    original: sqs_msg.body,
+    transformed: sqs_msg.body.upcase,
+    message_id: sqs_msg.message_id
+  }
+end
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  def perform(sqs_msg, body)
+    DT[:parsed_bodies] << body
+    DT[:body_classes] << body.class.name
+  end
+end
+
+worker_class.get_shoryuken_options['queue'] = queue_name
+worker_class.get_shoryuken_options['auto_delete'] = true
+worker_class.get_shoryuken_options['body_parser'] = custom_parser
+Shoryuken.register_worker(queue_name, worker_class)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a message to be processed by custom parser
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: 'hello world'
+)
+
+sleep 1
+
+poll_queues_until { DT[:parsed_bodies].size >= 1 }
+
+assert_equal(1, DT[:parsed_bodies].size)
+assert_equal('Hash', DT[:body_classes].first)
+
+parsed = DT[:parsed_bodies].first
+assert_equal('hello world', parsed[:original])
+assert_equal('HELLO WORLD', parsed[:transformed])
+assert(parsed[:message_id], "Should include message_id from sqs_msg")

--- a/spec/integration/body_parser/text_parser_spec.rb
+++ b/spec/integration/body_parser/text_parser_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# This spec tests the body_parser option with :text setting (default)
+# Verifies that messages are returned as plain strings
+
+setup_localstack
+
+queue_name = DT.uuid
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options body_parser: :text
+
+  def perform(sqs_msg, body)
+    DT[:parsed_bodies] << body
+    DT[:body_classes] << body.class.name
+  end
+end
+
+worker_class.get_shoryuken_options['queue'] = queue_name
+worker_class.get_shoryuken_options['auto_delete'] = true
+Shoryuken.register_worker(queue_name, worker_class)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a plain text message
+text_body = 'Hello, this is a plain text message!'
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: text_body
+)
+
+sleep 1
+
+poll_queues_until { DT[:parsed_bodies].size >= 1 }
+
+assert_equal(1, DT[:parsed_bodies].size)
+assert_equal('String', DT[:body_classes].first)
+assert_equal(text_body, DT[:parsed_bodies].first)


### PR DESCRIPTION
## Summary
Adds integration specs for the `body_parser` worker option to improve test coverage.

## Tests Added

### json_parser_spec.rb
Tests `:json` body parser - verifies JSON strings are automatically parsed into Ruby hashes with nested structure support.

### text_parser_spec.rb  
Tests `:text` body parser (default) - verifies messages are returned as plain strings.

### proc_parser_spec.rb
Tests custom `Proc` body parser - verifies custom parsing logic can access the full `sqs_msg` object and transform the body.

## Test plan
- [x] All 3 new specs pass locally: `./bin/integrations body_parser` - 3/3 passed

Part of #787