### PR TITLE
Add warning monitoring to test suite

### DIFF
--- a/shoryuken.gemspec
+++ b/shoryuken.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'warning'
 
   spec.required_ruby_version = '>= 3.2.0'
 end

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -2,6 +2,34 @@
 
 # Integration test helper for process-isolated testing
 
+# Enable Ruby warnings to catch deprecations and potential issues
+Warning[:performance] = true if RUBY_VERSION >= '3.3'
+Warning[:deprecated] = true
+$VERBOSE = true
+
+require 'warning'
+
+# Process warnings and raise on unexpected ones from our code
+Warning.process do |warning|
+  # Only check warnings from our code (not dependencies)
+  next unless warning.include?(Dir.pwd)
+
+  # Filter out warnings we don't care about in specs
+  next if warning.include?('_spec')
+
+  # We redefine methods to simulate various scenarios in tests
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+
+  # Ignore vendor directory
+  next if warning.include?('vendor/')
+
+  # Ignore bundle path
+  next if warning.include?('bundle/')
+
+  raise "Warning in your code: #{warning}"
+end
+
 require 'timeout'
 require 'json'
 require 'securerandom'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,20 @@ $VERBOSE = true
 require 'warning'
 
 Warning.process do |warning|
-  next
+  # Only check warnings from our code (not dependencies)
   next unless warning.include?(Dir.pwd)
-  next if warning.include?('useless use of a variable in void context') && warning.include?('core_ext')
+
+  # Filter out warnings we don't care about in specs
+  next if warning.include?('_spec')
+
+  # We redefine methods to simulate various scenarios in tests
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+
+  # Ignore vendor and bundle directories
   next if warning.include?('vendor/')
+  next if warning.include?('bundle/')
+  next if warning.include?('.bundle/')
 
   raise "Warning in your code: #{warning}"
 end


### PR DESCRIPTION
## Summary
Enable Ruby warning monitoring in both unit tests and integration tests to catch deprecations and potential issues early.

## Changes
- Add `warning` gem to development dependencies
- Update `spec/spec_helper.rb` to enable and process warnings (fixed the short-circuiting `next` statement)
- Update `spec/integrations_helper.rb` with warning monitoring

## How it works
- Enables Ruby's deprecation warnings (`Warning[:deprecated] = true`)
- Enables performance warnings for Ruby 3.3+ (`Warning[:performance] = true`)
- Uses the `warning` gem to process warnings and raise on unexpected ones from our code
- Filters out expected warnings (spec files, vendor dirs, method redefinitions used in tests)

Based on [Karafka's approach](https://github.com/karafka/karafka/blob/master/spec/integrations_helper.rb#L5) to warning monitoring.

## Test plan
- [x] All 473 unit specs pass
- [x] All 39 integration specs pass

Closes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test infrastructure with improved warning detection and filtering to catch code quality issues more effectively.
  * Added development dependencies to support better warning handling during testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->