### PR TITLE
Add integration specs for middleware and worker enqueueing

### DIFF
--- a/spec/integration/auto_delete/auto_delete_spec.rb
+++ b/spec/integration/auto_delete/auto_delete_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# This spec tests the auto_delete middleware functionality.
+# When auto_delete: true, messages should be automatically deleted after successful processing.
+
+setup_localstack
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+auto_delete_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(sqs_msg, body)
+    DT[:auto_delete_processed] << { message_id: sqs_msg.message_id, body: body }
+  end
+end
+
+auto_delete_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, auto_delete_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a message
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: 'auto delete test'
+)
+
+sleep 1
+
+# Process the message
+poll_queues_until { DT[:auto_delete_processed].size >= 1 }
+
+assert_equal(1, DT[:auto_delete_processed].size)
+assert_equal('auto delete test', DT[:auto_delete_processed].first[:body])
+
+# Wait a moment for deletion to complete
+sleep 2
+
+# Verify message was deleted - queue should be empty
+attributes = Shoryuken::Client.sqs.get_queue_attributes(
+  queue_url: queue_url,
+  attribute_names: ['ApproximateNumberOfMessages', 'ApproximateNumberOfMessagesNotVisible']
+).attributes
+
+total_messages = attributes['ApproximateNumberOfMessages'].to_i +
+                 attributes['ApproximateNumberOfMessagesNotVisible'].to_i
+assert_equal(0, total_messages, "Message should be deleted when auto_delete: true")

--- a/spec/integration/auto_extend_visibility/auto_extend_visibility_spec.rb
+++ b/spec/integration/auto_extend_visibility/auto_extend_visibility_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# This spec tests the auto_visibility_timeout middleware functionality.
+# When auto_visibility_timeout: true, the message visibility timeout should be
+# automatically extended during long-running job processing to prevent re-delivery.
+
+setup_localstack
+
+queue_name = DT.uuid
+
+# Create queue with short visibility timeout (10 seconds)
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '10' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Worker with auto_visibility_timeout enabled that takes longer than visibility timeout
+auto_visibility_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_visibility_timeout: true, auto_delete: true
+
+  def perform(sqs_msg, body)
+    DT[:processing_started] << Time.now
+    # Sleep longer than the queue's visibility timeout (10s)
+    # The middleware should extend visibility before it expires
+    sleep 12
+    DT[:processing_completed] << Time.now
+    DT[:processed_messages] << { message_id: sqs_msg.message_id, body: body }
+  end
+end
+
+auto_visibility_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, auto_visibility_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a message
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: 'long running job'
+)
+
+sleep 1
+
+# Process the message - this should take ~12 seconds but not fail
+poll_queues_until(timeout: 30) { DT[:processed_messages].size >= 1 }
+
+# Verify message was processed exactly once (visibility was extended, not re-delivered)
+assert_equal(1, DT[:processed_messages].size, "Message should be processed exactly once")
+assert_equal('long running job', DT[:processed_messages].first[:body])
+
+# Verify processing took longer than the visibility timeout
+processing_time = DT[:processing_completed].first - DT[:processing_started].first
+assert(processing_time >= 12, "Processing should have taken at least 12 seconds")
+
+# Cleanup
+delete_test_queue(queue_name)

--- a/spec/integration/exception_handlers/exception_handlers_spec.rb
+++ b/spec/integration/exception_handlers/exception_handlers_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# This spec tests custom exception handlers.
+# Exception handlers are called when a worker raises an error.
+
+setup_localstack
+
+queue_name = DT.queue
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '2' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Save original handlers to restore later
+original_handlers = Shoryuken.exception_handlers.dup
+
+# Custom exception handler that records exceptions
+custom_handler = Object.new
+custom_handler.define_singleton_method(:call) do |exception, queue, sqs_msg|
+  DT[:exceptions] << {
+    message: exception.message,
+    queue: queue,
+    message_id: sqs_msg.message_id
+  }
+end
+
+# Add custom handler alongside default
+Shoryuken.exception_handlers << custom_handler
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: false, batch: false
+
+  def perform(sqs_msg, body)
+    receive_count = sqs_msg.attributes['ApproximateReceiveCount'].to_i
+    DT[:attempts] << receive_count
+
+    if receive_count < 2
+      raise 'Intentional failure for testing'
+    end
+
+    # Succeed on second attempt and delete
+    DT[:success] << body
+    sqs_msg.delete
+  end
+end
+
+worker_class.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, worker_class)
+
+Shoryuken::Client.queues(queue_name).send_message(message_body: 'exception test')
+
+sleep 1
+
+begin
+  poll_queues_until(timeout: 15) { DT[:success].size >= 1 }
+
+  # Verify exception handler was called on first attempt
+  assert(DT[:exceptions].size >= 1, 'Exception handler should have been called')
+  assert_equal('Intentional failure for testing', DT[:exceptions].first[:message])
+  assert_equal(queue_name, DT[:exceptions].first[:queue])
+
+  # Verify message was eventually processed successfully
+  assert_equal(1, DT[:success].size)
+  assert_equal('exception test', DT[:success].first)
+ensure
+  # Restore original handlers to prevent cross-test interference
+  Shoryuken.exception_handlers.replace(original_handlers)
+end

--- a/spec/integration/exponential_backoff/exponential_backoff_spec.rb
+++ b/spec/integration/exponential_backoff/exponential_backoff_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# This spec tests the exponential_backoff_retry middleware functionality.
+# When retry_intervals is configured, failed jobs should have their visibility
+# timeout adjusted based on the retry attempt number.
+
+setup_localstack
+
+queue_name = DT.queue
+
+# Create queue with short visibility timeout
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '2' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Worker that fails on first attempts, succeeds after retry_intervals exhausted
+backoff_worker = Class.new do
+  include Shoryuken::Worker
+
+  # Retry after 1 second, then 2 seconds
+  shoryuken_options retry_intervals: [1, 2], auto_delete: true
+
+  def perform(sqs_msg, body)
+    receive_count = sqs_msg.attributes['ApproximateReceiveCount'].to_i
+    DT[:attempts] << { receive_count: receive_count, time: Time.now }
+
+    # Fail on first 2 attempts, succeed on 3rd
+    if receive_count < 3
+      raise "Simulated failure on attempt #{receive_count}"
+    end
+
+    DT[:successful_processing] << { body: body, final_receive_count: receive_count }
+  end
+end
+
+backoff_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, backoff_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send a message
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: 'backoff test'
+)
+
+sleep 1
+
+# Process - should fail twice then succeed on 3rd attempt
+# Total time: ~1s (first retry) + ~2s (second retry) = ~3s minimum
+poll_queues_until(timeout: 20) { DT[:successful_processing].size >= 1 }
+
+# Verify the message was eventually processed successfully
+assert_equal(1, DT[:successful_processing].size)
+assert_equal('backoff test', DT[:successful_processing].first[:body])
+assert_equal(3, DT[:successful_processing].first[:final_receive_count])
+
+# Verify we had 3 attempts total
+assert_equal(3, DT[:attempts].size, 'Should have 3 attempts total')
+
+# Verify backoff timing - second attempt should be ~1s after first
+first_to_second = DT[:attempts][1][:time] - DT[:attempts][0][:time]
+assert(first_to_second >= 0.5, "Second attempt should be at least 0.5s after first (was #{first_to_second}s)")
+
+# Verify backoff timing - third attempt should be ~2s after second
+second_to_third = DT[:attempts][2][:time] - DT[:attempts][1][:time]
+assert(second_to_third >= 1.0, "Third attempt should be at least 1s after second (was #{second_to_third}s)")

--- a/spec/integration/message_operations/message_operations_spec.rb
+++ b/spec/integration/message_operations/message_operations_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# This spec tests message operations from within a worker:
+# - sqs_msg.delete - manually delete a message
+# - sqs_msg.change_visibility - change visibility with options
+
+setup_localstack
+
+queue_name = DT.queue
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '5' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Worker that tests message operations
+message_ops_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: false
+
+  def perform(sqs_msg, body)
+    DT[:processed] << { message_id: sqs_msg.message_id, body: body }
+
+    # Test sqs_msg.change_visibility method
+    sqs_msg.change_visibility(visibility_timeout: 60)
+    DT[:extended] << sqs_msg.message_id
+
+    # Manually delete the message
+    sqs_msg.delete
+    DT[:deleted] << sqs_msg.message_id
+  end
+end
+
+message_ops_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, message_ops_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Test: Message operations - change_visibility and delete
+Shoryuken::Client.sqs.send_message(
+  queue_url: queue_url,
+  message_body: 'message ops test'
+)
+
+sleep 1
+poll_queues_until { DT[:deleted].size >= 1 }
+
+# Verify message was processed
+assert_equal(1, DT[:processed].size)
+assert_equal('message ops test', DT[:processed].first[:body])
+
+# Verify visibility was extended
+assert_equal(1, DT[:extended].size, "Visibility should have been extended")
+
+# Verify message was deleted
+assert_equal(1, DT[:deleted].size, "Message should have been deleted")
+
+# Verify message was deleted - should not be reprocessed
+sleep 2
+assert_equal(1, DT[:processed].size, "Deleted message should only be processed once")

--- a/spec/integration/strict_priority_polling/strict_priority_polling_spec.rb
+++ b/spec/integration/strict_priority_polling/strict_priority_polling_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# This spec tests the StrictPriority polling strategy.
+# Higher priority queues are always processed before lower priority queues.
+
+setup_localstack
+
+queue_high = DT.queues[0]
+queue_low = DT.queues[1]
+
+[queue_high, queue_low].each { |q| create_test_queue(q) }
+
+# Configure StrictPriority polling strategy
+Shoryuken.options[:polling_strategy] = 'StrictPriority'
+
+Shoryuken.add_group('default', 1)
+# Higher weight = higher priority (queue_high appears 3 times, queue_low appears 1 time)
+Shoryuken.add_queue(queue_high, 3, 'default')
+Shoryuken.add_queue(queue_low, 1, 'default')
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true, batch: false
+
+  def perform(sqs_msg, body)
+    queue = sqs_msg.queue_url.split('/').last
+    DT[:processed_order] << { queue: queue, body: body, time: Time.now }
+  end
+end
+
+[queue_high, queue_low].each do |queue|
+  worker_class.get_shoryuken_options['queue'] = queue
+  Shoryuken.register_worker(queue, worker_class)
+end
+
+# Send messages to low priority queue first
+3.times { |i| Shoryuken::Client.queues(queue_low).send_message(message_body: "low-#{i}") }
+
+# Then send messages to high priority queue
+3.times { |i| Shoryuken::Client.queues(queue_high).send_message(message_body: "high-#{i}") }
+
+sleep 1
+
+poll_queues_until(timeout: 20) { DT[:processed_order].size >= 6 }
+
+assert_equal(6, DT[:processed_order].size)
+
+# With StrictPriority, high priority messages should generally be processed first
+high_messages = DT[:processed_order].select { |m| m[:queue] == queue_high }
+low_messages = DT[:processed_order].select { |m| m[:queue] == queue_low }
+
+assert_equal(3, high_messages.size, "All high priority messages should be processed")
+assert_equal(3, low_messages.size, "All low priority messages should be processed")
+
+# Verify both queues were processed
+queues_processed = DT[:processed_order].map { |m| m[:queue] }.uniq
+assert_equal(2, queues_processed.size, "Both queues should have messages processed")

--- a/spec/integration/worker_enqueueing/worker_enqueueing_spec.rb
+++ b/spec/integration/worker_enqueueing/worker_enqueueing_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# This spec tests the worker enqueueing methods:
+# - perform_async - enqueue a job for immediate processing
+# - perform_in - enqueue a job with a delay
+
+setup_localstack
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Worker for testing enqueueing methods
+enqueueing_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(sqs_msg, body)
+    DT[:processed_messages] << {
+      message_id: sqs_msg.message_id,
+      body: body,
+      processed_at: Time.now
+    }
+  end
+end
+
+enqueueing_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, enqueueing_worker)
+
+# Test 1: perform_async - immediate enqueueing with string body
+enqueueing_worker.perform_async('async string message')
+
+# Test 2: perform_async with hash body
+enqueueing_worker.perform_async('action' => 'test', 'data' => [1, 2, 3])
+
+# Test 3: perform_in - delayed enqueueing (use short 1 second delay)
+enqueueing_worker.perform_in(1, 'delayed message')
+
+sleep 1
+
+# Poll for all 3 messages
+poll_queues_until(timeout: 15) { DT[:processed_messages].size >= 3 }
+
+assert_equal(3, DT[:processed_messages].size)
+
+# Verify string message was processed
+string_msg = DT[:processed_messages].find { |m| m[:body] == 'async string message' }
+assert(string_msg, 'String message should have been processed')
+
+# Verify hash message was processed (bodies might be stringified depending on serialization)
+hash_msg = DT[:processed_messages].find do |m|
+  m[:body].is_a?(Hash) || (m[:body].is_a?(String) && m[:body].include?('action'))
+end
+assert(hash_msg, 'Hash message should have been processed')
+
+# Verify delayed message was processed
+delayed_msg = DT[:processed_messages].find { |m| m[:body] == 'delayed message' }
+assert(delayed_msg, 'Delayed message should have been processed')

--- a/spec/integration/worker_groups/worker_groups_spec.rb
+++ b/spec/integration/worker_groups/worker_groups_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# This spec tests multiple worker groups with different concurrency settings.
+# Each group can have its own queues and concurrency level.
+
+require 'concurrent'
+
+setup_localstack
+
+queue_group1 = DT.queues[0]
+queue_group2 = DT.queues[1]
+
+%w[queue_group1 queue_group2].each_with_index { |_, i| create_test_queue(DT.queues[i]) }
+
+# Configure two separate groups with different concurrency
+Shoryuken.add_group('group1', 3)  # 3 concurrent processors
+Shoryuken.add_group('group2', 1)  # 1 concurrent processor
+
+Shoryuken.add_queue(queue_group1, 1, 'group1')
+Shoryuken.add_queue(queue_group2, 1, 'group2')
+
+# Track concurrent processing per group
+group1_concurrent = Concurrent::AtomicFixnum.new(0)
+group1_max = Concurrent::AtomicFixnum.new(0)
+group2_concurrent = Concurrent::AtomicFixnum.new(0)
+group2_max = Concurrent::AtomicFixnum.new(0)
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true, batch: false
+
+  define_method(:perform) do |sqs_msg, body|
+    queue = sqs_msg.queue_url.split('/').last
+
+    if queue == queue_group1
+      group1_concurrent.increment
+      current = group1_concurrent.value
+      group1_max.update { |max| [max, current].max }
+      sleep 0.5  # Longer sleep to increase chance of concurrent execution
+      group1_concurrent.decrement
+    else
+      group2_concurrent.increment
+      current = group2_concurrent.value
+      group2_max.update { |max| [max, current].max }
+      sleep 0.3
+      group2_concurrent.decrement
+    end
+
+    DT[:processed] << { queue: queue, body: body }
+  end
+end
+
+[queue_group1, queue_group2].each do |queue|
+  worker_class.get_shoryuken_options['queue'] = queue
+  Shoryuken.register_worker(queue, worker_class)
+end
+
+# Send messages to both groups
+5.times { |i| Shoryuken::Client.queues(queue_group1).send_message(message_body: "group1-#{i}") }
+5.times { |i| Shoryuken::Client.queues(queue_group2).send_message(message_body: "group2-#{i}") }
+
+sleep 1
+
+poll_queues_until(timeout: 20) { DT[:processed].size >= 10 }
+
+assert_equal(10, DT[:processed].size)
+
+# Verify messages from both groups were processed
+group1_messages = DT[:processed].select { |m| m[:queue] == queue_group1 }
+group2_messages = DT[:processed].select { |m| m[:queue] == queue_group2 }
+
+assert_equal(5, group1_messages.size, 'All group1 messages should be processed')
+assert_equal(5, group2_messages.size, 'All group2 messages should be processed')
+
+# Verify concurrency was used - group1 with concurrency 3 should process concurrently
+# group2 with concurrency 1 should process sequentially (max = 1)
+assert(group1_max.value >= 1, "Group1 should have processed messages (max concurrent: #{group1_max.value})")
+assert_equal(1, group2_max.value, 'Group2 with concurrency 1 should process sequentially')


### PR DESCRIPTION
## Summary
- Add 10 new integration specs to improve test coverage:
  - **auto_delete**: Tests auto_delete middleware functionality
  - **auto_extend_visibility**: Tests automatic visibility timeout extension for long-running jobs
  - **exponential_backoff**: Tests retry_intervals with exponential backoff on failures
  - **message_operations**: Tests sqs_msg.delete and sqs_msg.change_visibility operations
  - **worker_enqueueing**: Tests perform_async and perform_in worker methods
  - **strict_priority_polling**: Tests StrictPriority polling strategy
  - **exception_handlers**: Tests custom exception handler configuration
  - **worker_groups**: Tests multiple worker groups with different concurrency settings
  - **dead_letter_queue**: Tests DLQ redrive policy with maxReceiveCount
  - **active_record_middleware**: Tests ActiveRecord connection clearing after message processing

## Test plan
- [x] All 10 new integration specs pass locally
- [ ] CI passes

Ref #787