### PR TITLE
Add DLQ and ActiveRecord middleware integration specs

### DIFF
--- a/spec/integration/active_record_middleware/active_record_middleware_spec.rb
+++ b/spec/integration/active_record_middleware/active_record_middleware_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# This spec tests the ActiveRecord middleware functionality.
+# The middleware clears database connections after each message is processed.
+
+setup_localstack
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Mock ActiveRecord module to track connection clearing
+module ActiveRecord
+  VERSION = Gem::Version.new('7.2.0')
+
+  def self.version
+    VERSION
+  end
+
+  class Base
+    class << self
+      attr_accessor :connections_cleared
+
+      def connection_handler
+        @connection_handler ||= ConnectionHandler.new
+      end
+    end
+
+    self.connections_cleared = []
+  end
+
+  class ConnectionHandler
+    def clear_active_connections!(scope)
+      ActiveRecord::Base.connections_cleared << { scope: scope, time: Time.now }
+    end
+  end
+end
+
+# Add the ActiveRecord middleware to the chain
+require 'shoryuken/middleware/server/active_record'
+Shoryuken.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add Shoryuken::Middleware::Server::ActiveRecord
+  end
+end
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true, batch: false
+
+  def perform(sqs_msg, body)
+    DT[:processed] << { message_id: sqs_msg.message_id, body: body }
+  end
+end
+
+worker_class.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, worker_class)
+
+# Clear any prior connection clearing records
+ActiveRecord::Base.connections_cleared.clear
+
+# Send multiple messages
+3.times { |i| Shoryuken::Client.queues(queue_name).send_message(message_body: "ar-test-#{i}") }
+
+sleep 1
+
+poll_queues_until { DT[:processed].size >= 3 }
+
+# Verify all messages were processed
+assert_equal(3, DT[:processed].size)
+
+# Verify ActiveRecord connections were cleared after each message
+# The middleware should have called clear_active_connections! for each message
+assert(
+  ActiveRecord::Base.connections_cleared.size >= 3,
+  "ActiveRecord connections should be cleared after each message (cleared #{ActiveRecord::Base.connections_cleared.size} times)"
+)
+
+# Verify the :all scope was used (Rails 7.1+ behavior)
+ActiveRecord::Base.connections_cleared.each do |record|
+  assert_equal(:all, record[:scope], 'Should use :all scope for Rails 7.1+')
+end

--- a/spec/integration/dead_letter_queue/dead_letter_queue_spec.rb
+++ b/spec/integration/dead_letter_queue/dead_letter_queue_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# This spec tests dead letter queue (DLQ) functionality.
+# When a message exceeds maxReceiveCount, it should be moved to the DLQ.
+# Note: This test doesn't use poll_queues_until because messages should fail
+# and be moved to DLQ rather than being successfully processed.
+
+setup_localstack
+
+main_queue_name = DT.queues[0]
+dlq_name = DT.queues[1]
+
+# Create the dead letter queue first
+create_test_queue(dlq_name)
+
+dlq_url = Shoryuken::Client.sqs.get_queue_url(queue_name: dlq_name).queue_url
+dlq_arn = Shoryuken::Client.sqs.get_queue_attributes(
+  queue_url: dlq_url,
+  attribute_names: ['QueueArn']
+).attributes['QueueArn']
+
+# Create main queue with redrive policy - move to DLQ after 2 receives
+redrive_policy = { maxReceiveCount: 2, deadLetterTargetArn: dlq_arn }.to_json
+create_test_queue(main_queue_name, attributes: {
+  'VisibilityTimeout' => '1',
+  'RedrivePolicy' => redrive_policy
+})
+
+main_queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: main_queue_name).queue_url
+
+# Send a message
+Shoryuken::Client.sqs.send_message(
+  queue_url: main_queue_url,
+  message_body: 'dlq test message'
+)
+
+# Manually receive the message multiple times to trigger DLQ
+# maxReceiveCount = 2, so after 2 receives without deletion, it goes to DLQ
+3.times do |i|
+  msgs = Shoryuken::Client.sqs.receive_message(
+    queue_url: main_queue_url,
+    max_number_of_messages: 1,
+    wait_time_seconds: 3,
+    attribute_names: ['ApproximateReceiveCount']
+  ).messages
+
+  if msgs.any?
+    receive_count = msgs.first.attributes['ApproximateReceiveCount'].to_i
+    DT[:receives] << { attempt: i + 1, receive_count: receive_count }
+    # Don't delete - let visibility timeout expire
+    sleep 2
+  else
+    DT[:receives] << { attempt: i + 1, no_message: true }
+    break
+  end
+end
+
+# Verify message was received at least twice
+actual_receives = DT[:receives].reject { |r| r[:no_message] }
+assert(actual_receives.size >= 2, "Message should have been received at least twice (was #{actual_receives.size})")
+
+# Wait for message to be moved to DLQ
+sleep 3
+
+# Check that message is now in the DLQ
+dlq_messages = Shoryuken::Client.sqs.receive_message(
+  queue_url: dlq_url,
+  max_number_of_messages: 10,
+  wait_time_seconds: 5,
+  attribute_names: ['All']
+).messages
+
+assert(dlq_messages.size >= 1, 'Message should have been moved to DLQ')
+assert_equal('dlq test message', dlq_messages.first.body)
+
+# Verify message is no longer in main queue
+main_attrs = Shoryuken::Client.sqs.get_queue_attributes(
+  queue_url: main_queue_url,
+  attribute_names: %w[ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible]
+).attributes
+main_count = main_attrs['ApproximateNumberOfMessages'].to_i +
+             main_attrs['ApproximateNumberOfMessagesNotVisible'].to_i
+assert_equal(0, main_count, 'Main queue should be empty after DLQ move')
+
+# Clean up DLQ message
+dlq_messages.each do |msg|
+  Shoryuken::Client.sqs.delete_message(
+    queue_url: dlq_url,
+    receipt_handle: msg.receipt_handle
+  )
+end


### PR DESCRIPTION
## Summary
- Add 2 new integration specs to improve test coverage:
  - **dead_letter_queue**: Tests DLQ redrive policy with maxReceiveCount
  - **active_record_middleware**: Tests ActiveRecord connection clearing after message processing

## Test plan
- [x] Both new integration specs pass locally
- [ ] CI passes

Ref #787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test for ActiveRecord middleware database connection clearing functionality
  * Added integration test for dead letter queue message handling and redrive policies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->