### PR TITLE
Raise ArgumentError when using delay with FIFO queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [7.0.0] - Unreleased
+- Fix: Raise ArgumentError when using delay with FIFO queues
+  - FIFO queues do not support per-message DelaySeconds
+  - Previously caused confusing AWS errors with ActiveJob's `retry_on` (Rails 6.1+ defaults to `wait: 3.seconds`)
+  - Now raises clear ArgumentError with guidance to use `wait: 0`
+  - Fixes #924
+
 - Enhancement: Use fiber-local storage for logging context
   - Replaces thread-local storage with Fiber[] for proper isolation in async environments
   - Ensures logging context doesn't leak between fibers in the same thread


### PR DESCRIPTION
FIFO queues in SQS do not support per-message DelaySeconds. This caused confusing AWS errors when using ActiveJob's retry_on with FIFO queues, since Rails 6.1+ defaults to wait: 3.seconds.

Add early validation in enqueue_at to raise a clear ArgumentError with actionable guidance when attempting to use delays with FIFO queues. The check happens before any async wrapping to ensure synchronous failure.

Fixes #924

close https://github.com/ruby-shoryuken/shoryuken/issues/924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for FIFO queues that raises an error when delays are used, preventing incompatible configurations and providing clearer feedback.

* **Documentation**
  * Updated documentation to clarify FIFO queue behavior with delays and retry mechanisms.

* **Tests**
  * Added test coverage for FIFO queue delay validation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->