### PR TITLE
Fix bundler environment isolation in integration tests

### DIFF
--- a/bin/integrations
+++ b/bin/integrations
@@ -10,6 +10,7 @@
 #   bin/integrations batch retry        # Run tests matching 'batch' OR 'retry'
 #   bin/integrations -v fifo            # Run with verbose output
 
+require 'bundler'
 require 'fileutils'
 require 'timeout'
 
@@ -88,9 +89,11 @@ class IntegrationRunner
   end
 
   def run_spec(spec)
+    # Start with a clean bundler environment to prevent pollution between tests
     env = {
       'BUNDLE_GEMFILE' => spec[:gemfile],
-      'RAILS_ENV' => 'test'
+      'RAILS_ENV' => 'test',
+      'RUBYOPT' => nil  # Clear any -rbundler/setup from CI or previous tests
     }
 
     # Install dependencies if using a local Gemfile
@@ -131,8 +134,13 @@ class IntegrationRunner
 
     begin
       Timeout.timeout(TIMEOUT) do
-        IO.popen(env, cmd, chdir: spec[:directory], err: [:child, :out]) do |io|
-          io.each_line { |line| output << line }
+        # Use unbundled env to prevent pollution from previous test runs
+        # This is especially important after Rails integration tests that use
+        # bundle install --standalone with different gem versions
+        Bundler.with_unbundled_env do
+          IO.popen(env, cmd, chdir: spec[:directory], err: [:child, :out]) do |io|
+            io.each_line { |line| output << line }
+          end
         end
       end
 


### PR DESCRIPTION
## Summary
- Use `Bundler.with_unbundled_env` to wrap spec execution to prevent bundler state pollution between test runs
- Clear `RUBYOPT` in the env to prevent automatic bundler/setup loading from CI or previous tests

## Problem
After Rails integration tests run (which use `bundle install --standalone` with different gem versions), subsequent non-Rails tests would fail because bundler was picking up cached configuration from the Rails test bundle. This manifested as errors like:

```
Could not find activejob-7.2.3, activesupport-7.2.3, benchmark-0.5.0 in locally installed gems
```

The root Gemfile has `activejob 8.0.1`, but bundler was looking for `7.2.3` from the Rails 7.2 integration test.

## Test plan
- CI will run integration tests on all Ruby versions (3.2, 3.3, 3.4, 4.0)
- Tests that previously failed after Rails tests should now pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test runner to prevent bundler environment pollution across tests, improving test reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->