### PR TITLE
Remove unused Shutdown class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@
   - `Shoryuken::Errors::InvalidEventError` for invalid lifecycle event names
   - `Shoryuken::Errors::InvalidDelayError` for delays exceeding SQS 15-minute maximum
   - `Shoryuken::Errors::InvalidArnError` for invalid ARN format
-  - `Shoryuken::Errors::Shutdown` for graceful shutdown (replaces `Shoryuken::Shutdown`)
   - Replaces generic Ruby exceptions (ArgumentError, RuntimeError) with specific error types
-  - Code rescuing `Shoryuken::Shutdown` must change to `Shoryuken::Errors::Shutdown`
+
+- Removed: `Shoryuken::Shutdown` class
+  - This class was unused since the Celluloid removal in 2016
+  - Originally used to raise on worker threads during hard shutdown
+  - Current shutdown flow uses `Interrupt` and executor-level shutdown instead
 
 - Fix: Raise ArgumentError when using delay with FIFO queues
   - FIFO queues do not support per-message DelaySeconds

--- a/lib/shoryuken/errors.rb
+++ b/lib/shoryuken/errors.rb
@@ -29,9 +29,5 @@ module Shoryuken
 
     # Raised when an ARN format is invalid
     InvalidArnError = Class.new(BaseError)
-
-    # Exception raised to trigger graceful shutdown of the server
-    # @see https://github.com/mperham/sidekiq/blob/33f5d6b2b6c0dfaab11e5d39688cab7ebadc83ae/lib/sidekiq/cli.rb#L20
-    Shutdown = Class.new(Interrupt)
   end
 end


### PR DESCRIPTION
## Summary

- Remove `Shoryuken::Errors::Shutdown` class which has been unused since the Celluloid removal in 2016
- Update CHANGELOG to document the removal

## Background

The `Shutdown` class was originally introduced in 2015 as part of the "modern hard shutdown sequence from Sidekiq" (commit 4fa082d). It was used to raise on worker threads during hard shutdown in the Celluloid-based architecture:

```ruby
t.raise Shutdown  # raise on worker thread
```

This mechanism was removed when Shoryuken migrated from Celluloid to `Concurrent::FixedThreadPool` in 2016 (commit b8f0830). The current shutdown flow uses plain `Interrupt` and executor-level shutdown methods instead.

## Why remove it?

1. **Unused**: Not raised or rescued anywhere in the codebase
2. **Not documented**: Not mentioned in the wiki (Signals, Lifecycle Events, Deployment, Worker options pages)
3. **Doesn't fit the Errors module**: Inherits from `Interrupt`, not `BaseError` like all other error classes. Its purpose was control flow signaling, not error handling.

## Test plan

- [x] Verify no code references `Shutdown` class
- [x] Verify wiki doesn't document it
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Removed `Shoryuken::Shutdown` class from the public API. Graceful shutdown now uses `Interrupt` and executor-level mechanisms instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->