### PR TITLE
Extract linting tools to separate Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ group :test do
   gem 'multi_xml'
   gem 'simplecov'
   gem 'warning'
-  gem 'yard-lint'
 end
 
 group :development do

--- a/Gemfile.lint
+++ b/Gemfile.lint
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Documentation linting
+gem 'yard-lint'

--- a/Gemfile.lint.lock
+++ b/Gemfile.lint.lock
@@ -1,0 +1,23 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    yard (0.9.38)
+    yard-lint (1.4.0)
+      yard (~> 0.9)
+      zeitwerk (~> 2.6)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  yard-lint
+
+CHECKSUMS
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  yard-lint (1.4.0) sha256=7dd88fbb08fd77cb840bea899d58812817b36d92291b5693dd0eeb3af9f91f0f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.3

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "enabled": true,
     "managerFilePatterns": [
       "/(^|/)Gemfile$/",
+      "/(^|/)Gemfile\\.lint$/",
       "/\\.gemfile$/",
       "/(^|/)gems\\.rb$/",
       "/spec/gemfiles/.+\\.gemfile$/",


### PR DESCRIPTION
## Summary

- Move `yard-lint` to a separate `Gemfile.lint` to isolate non-execution/linting dependencies
- Add `Gemfile.lint` pattern to Renovate's bundler managerFilePatterns for automatic dependency updates

## Test plan

- [ ] Confirm Renovate detects and tracks `Gemfile.lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized linting dependencies by introducing a dedicated lint configuration file and moving the linting tool to this separate configuration.
  * Updated dependency management to recognize the new lint configuration file alongside existing patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->