### PR TITLE
Raise custom error for FIFO delay instead of ArgumentError

### DIFF
--- a/lib/active_job/queue_adapters/shoryuken_adapter.rb
+++ b/lib/active_job/queue_adapters/shoryuken_adapter.rb
@@ -98,7 +98,7 @@ module ActiveJob
       # @param job [ActiveJob::Base] the job to enqueue
       # @param timestamp [Float] Unix timestamp when the job should be processed
       # @return [Aws::SQS::Types::SendMessageResult] the send result
-      # @raise [ArgumentError] if delay is used with a FIFO queue
+      # @raise [Shoryuken::Errors::FifoDelayNotSupportedError] if delay is used with a FIFO queue
       def enqueue_at(job, timestamp) # :nodoc:
         delay = calculate_delay(timestamp)
 
@@ -110,7 +110,7 @@ module ActiveJob
         if delay.positive?
           queue = Shoryuken::Client.queues(job.queue_name)
           if queue.fifo?
-            raise ArgumentError,
+            raise Shoryuken::Errors::FifoDelayNotSupportedError,
                   "FIFO queue '#{queue.name}' does not support per-message delays. " \
                   'When using ActiveJob retry_on with FIFO queues, set `wait: 0`.'
           end

--- a/lib/shoryuken/errors.rb
+++ b/lib/shoryuken/errors.rb
@@ -27,6 +27,9 @@ module Shoryuken
     # Raised when a delay exceeds the maximum allowed by SQS (15 minutes)
     InvalidDelayError = Class.new(BaseError)
 
+    # Raised when a delay is used with a FIFO queue
+    FifoDelayNotSupportedError = Class.new(BaseError)
+
     # Raised when an ARN format is invalid
     InvalidArnError = Class.new(BaseError)
   end

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -285,13 +285,13 @@ RSpec.shared_examples 'active_job_adapters' do
     context 'when fifo' do
       let(:fifo) { true }
 
-      it 'raises ArgumentError when delay is positive' do
+      it 'raises FifoDelayNotSupportedError when delay is positive' do
         allow(subject).to receive(:calculate_delay).and_return(3)
         allow(queue).to receive(:name).and_return('test.fifo')
         expect(queue).not_to receive(:send_message)
 
         expect { subject.enqueue_at(job, nil) }.to raise_error(
-          ArgumentError, /FIFO queue.*does not support per-message delays/
+          Shoryuken::Errors::FifoDelayNotSupportedError, /FIFO queue.*does not support per-message delays/
         )
       end
 


### PR DESCRIPTION
Fixes https://github.com/ruby-shoryuken/shoryuken/issues/948

Replaces `ArgumentError` with a custom `FifoDelayNotSupportedError` when attempting to use delay with FIFO queues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when using delays with FIFO queues, now raises a more specific error type with clearer guidance on FIFO queue limitations and how to resolve the issue.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->