### PR TITLE
Release v7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [7.0.1] - 2026-02-02
+
+- Fix: Replace `ArgumentError` with custom `FifoDelayNotSupportedError` for FIFO delay errors
+  - Provides more specific error type for programmatic error handling
+  - [#957](https://github.com/ruby-shoryuken/shoryuken/pull/957)
+
 ## [7.0.0] - 2026-01-19
 
 **See the [Upgrading to 7.0](https://github.com/ruby-shoryuken/shoryuken/wiki/Upgrading-to-7.0) guide for detailed migration instructions.**

--- a/lib/shoryuken/version.rb
+++ b/lib/shoryuken/version.rb
@@ -2,5 +2,5 @@
 
 module Shoryuken
   # Current version of the Shoryuken gem
-  VERSION = '7.0.0'
+  VERSION = '7.0.1'
 end


### PR DESCRIPTION
## Summary

- Adds changelog entry for #957 (FifoDelayNotSupportedError)
- Bumps version to 7.0.1

## Changes

- `CHANGELOG.md`: Added entry for v7.0.1 documenting the `FifoDelayNotSupportedError` improvement from PR #957
- `lib/shoryuken/version.rb`: Bump version from 7.0.0 to 7.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for FIFO queue delay operations with a more specific error type for better exception handling and debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->