### PR TITLE
Add changelog entry for #957

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+- Fix: Replace `ArgumentError` with custom `FifoDelayNotSupportedError` for FIFO delay errors
+  - Provides more specific error type for programmatic error handling
+  - [#957](https://github.com/ruby-shoryuken/shoryuken/pull/957)
+
 ## [7.0.0] - 2026-01-19
 
 **See the [Upgrading to 7.0](https://github.com/ruby-shoryuken/shoryuken/wiki/Upgrading-to-7.0) guide for detailed migration instructions.**


### PR DESCRIPTION
## Summary

Adds missing changelog entry for #957 (FifoDelayNotSupportedError) under an [Unreleased] section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for FIFO delay-related scenarios with more specific error identification, enabling better programmatic error handling and clearer error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->