### PR TITLE
Fix ActiveJob keyword arguments support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+- Fix: ActiveJob keyword arguments support
+  - Jobs with keyword arguments were broken due to improper argument forwarding in `SQSSendMessageParametersSupport#initialize`
+  - Use Ruby's argument forwarding (`...`) to properly pass all arguments including keyword arguments
+  - [#962](https://github.com/ruby-shoryuken/shoryuken/pull/962)
+
 - Fix: Replace `ArgumentError` with custom `FifoDelayNotSupportedError` for FIFO delay errors
   - Provides more specific error type for programmatic error handling
   - [#957](https://github.com/ruby-shoryuken/shoryuken/pull/957)

--- a/lib/active_job/extensions.rb
+++ b/lib/active_job/extensions.rb
@@ -20,9 +20,10 @@ module Shoryuken
     module SQSSendMessageParametersSupport
       # Initializes a new ActiveJob instance with empty SQS parameters
       #
-      # @param arguments [Array] the job arguments
-      def initialize(*arguments)
-        super(*arguments)
+      # Uses argument forwarding (...) to properly pass all arguments including
+      # keyword arguments to the base class.
+      def initialize(...)
+        super(...)
         self.sqs_send_message_parameters = {}
       end
 

--- a/lib/shoryuken/version.rb
+++ b/lib/shoryuken/version.rb
@@ -2,5 +2,5 @@
 
 module Shoryuken
   # Current version of the Shoryuken gem
-  VERSION = '7.0.0'
+  VERSION = '7.0.1'
 end

--- a/spec/integration/active_job/keyword_arguments/keyword_arguments_spec.rb
+++ b/spec/integration/active_job/keyword_arguments/keyword_arguments_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Integration test for ActiveJob keyword arguments support
+# Regression test for: https://github.com/ruby-shoryuken/shoryuken/issues/961
+#
+# In Shoryuken 7.0, the SQSSendMessageParametersSupport module's initialize method
+# breaks keyword argument passing to ActiveJob jobs because it lacks ruby2_keywords.
+
+setup_localstack
+setup_active_job
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+
+# Job that accepts keyword arguments - this was broken in Shoryuken 7.0
+class KeywordArgumentsTestJob < ActiveJob::Base
+  def perform(name:, count:, enabled: false)
+    DT[:executions] << {
+      name: name,
+      count: count,
+      enabled: enabled,
+      job_id: job_id
+    }
+  end
+end
+
+KeywordArgumentsTestJob.queue_as(queue_name)
+
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+Shoryuken.register_worker(queue_name, Shoryuken::ActiveJob::JobWrapper)
+
+# Enqueue jobs with keyword arguments
+# This is where the bug manifests - the job instantiation fails
+KeywordArgumentsTestJob.perform_later(name: 'first', count: 1)
+KeywordArgumentsTestJob.perform_later(name: 'second', count: 2, enabled: true)
+
+poll_queues_until(timeout: 30) do
+  DT[:executions].size >= 2
+end
+
+assert_equal(2, DT[:executions].size, "Expected 2 job executions, got #{DT[:executions].size}")
+
+# Find the executions by name
+first_exec = DT[:executions].find { |e| e[:name] == 'first' }
+second_exec = DT[:executions].find { |e| e[:name] == 'second' }
+
+assert(first_exec, "Expected to find 'first' job execution")
+assert(second_exec, "Expected to find 'second' job execution")
+
+# Verify keyword arguments were passed correctly
+assert_equal('first', first_exec[:name])
+assert_equal(1, first_exec[:count])
+assert_equal(false, first_exec[:enabled])
+
+assert_equal('second', second_exec[:name])
+assert_equal(2, second_exec[:count])
+assert_equal(true, second_exec[:enabled])
+
+# Verify job IDs
+job_ids = DT[:executions].map { |e| e[:job_id] }
+assert(job_ids.all? { |id| id && !id.empty? }, "All jobs should have job IDs")
+assert_equal(2, job_ids.uniq.size, "All job IDs should be unique")


### PR DESCRIPTION
## Summary

Fixes #961

ActiveJob jobs with keyword arguments were broken in Shoryuken 7.0 because the `SQSSendMessageParametersSupport` module's `initialize` method did not properly forward keyword arguments to the base class.

## Solution

Use Ruby's argument forwarding (`...`) to ensure all arguments including keyword arguments are correctly passed through when prepending the module to `ActiveJob::Base`:

```ruby
def initialize(...)
  super(...)
  self.sqs_send_message_parameters = {}
end
```

This is the idiomatic Ruby 3 solution (Shoryuken requires Ruby >= 3.2).

## Changes

- Use argument forwarding (`...`) in `SQSSendMessageParametersSupport#initialize`
- Added unit tests for keyword-only and mixed positional/keyword arguments
- Added integration test for full round-trip verification
- Bumped version to 7.0.1
- Added changelog entry

## Test plan

- [x] Unit tests pass (`bundle exec rspec spec/lib/active_job/extensions_spec.rb`)
- [x] Integration test passes (`./bin/integrations keyword_arguments`)
- [x] Full test suite passes (495 examples, 0 failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ActiveJob keyword-argument forwarding so jobs receive keyword and mixed arguments correctly.
  * Replaced a generic FIFO delay error with a specific, catchable FIFO delay error.

* **Tests**
  * Added integration and unit tests covering keyword-argument and mixed positional/keyword scenarios.

* **Chores**
  * Bumped project version and updated changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->