### PR TITLE
chore(renovate): add internalChecksFilter strict to ruby setup group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,7 +56,8 @@
         "ruby/setup-ruby",
         "ruby"
       ],
-      "groupName": "ruby setup"
+      "groupName": "ruby setup",
+      "internalChecksFilter": "strict"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Ensures Renovate waits until both ruby and ruby/setup-ruby have cleared the minimumReleaseAge window before creating the grouped PR, preventing partial dependency update PRs that fail CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration for improved handling of dependency update checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ruby-shoryuken/shoryuken/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->