### PR TITLE
Enhancement: Use dynamic Ruby warning category opt-in in test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+- Enhancement: Use dynamic Ruby warning category opt-in in test helpers (mensfeld)
+  - Replace version-gated `Warning[:performance]` with `Warning.categories`-based auto-enablement
+  - Automatically enables all non-deprecated, non-experimental warning categories for forward compatibility
+  - Applied to both `spec/spec_helper.rb` and `spec/integrations_helper.rb`
+
 ## [7.0.2] - 2026-04-16
 
 - Enhancement: Replace LocalStack with ElasticMQ for SQS integration tests (mensfeld)

--- a/spec/integrations_helper.rb
+++ b/spec/integrations_helper.rb
@@ -7,6 +7,10 @@ Warning[:performance] = true if RUBY_VERSION >= '3.3'
 Warning[:deprecated] = true
 $VERBOSE = true
 
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
 require 'warning'
 
 # Process warnings and raise on unexpected ones from our code

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ Warning[:performance] = true if RUBY_VERSION >= '3.3'
 Warning[:deprecated] = true
 $VERBOSE = true
 
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
 require 'warning'
 
 Warning.process do |warning|


### PR DESCRIPTION
Replace the version-gated Warning[:performance] approach with a forward-compatible dynamic opt-in that automatically enables all non-deprecated, non-experimental warning categories using Warning.categories (available in Ruby 3.4+).

Mirrors the approach from karafka/rdkafka-ruby#889.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test infrastructure to enable broader Ruby warning detection across supported versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->