### PR TITLE
Fix non_retryable_exceptions being ignored when retry_intervals is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Fix: `non_retryable_exceptions` is no longer ignored when `retry_intervals` is also configured (mensfeld)
+  - `ExponentialBackoffRetry` swallowed every exception after scheduling a retry, so `NonRetryableException`
+    (which sits outside it in the default middleware chain) never saw non-retryable errors - poison messages
+    were retried indefinitely (with the last interval repeated) instead of being deleted immediately
+  - `ExponentialBackoffRetry` now re-raises exceptions classified as non-retryable so the message gets deleted
+  - Exception classification is extracted to `NonRetryableException.non_retryable?` and shared by both middlewares
+
 - Enhancement: Use dynamic Ruby warning category opt-in in test helpers (mensfeld)
   - Replace version-gated `Warning[:performance]` with `Warning.categories`-based auto-enablement
   - Automatically enables all non-deprecated, non-experimental warning categories for forward compatibility

--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -17,8 +17,8 @@ module Shoryuken
         # @param _body [Object] the parsed message body (unused)
         # @yield continues to the next middleware in the chain
         # @return [void]
-        # @raise [StandardError] re-raises the original exception if retry intervals are not configured
-        #   or if retry limit is exceeded
+        # @raise [StandardError] re-raises the original exception if retry intervals are not configured,
+        #   if retry limit is exceeded, or if the exception is classified as non-retryable
         def call(worker, _queue, sqs_msg, _body)
           return yield unless worker.class.exponential_backoff?
 
@@ -30,7 +30,12 @@ module Shoryuken
           started_at = Time.now
           yield
         rescue => e
-          retry_intervals = worker.class.get_shoryuken_options['retry_intervals']
+          worker_options = worker.class.get_shoryuken_options
+          retry_intervals = worker_options['retry_intervals']
+
+          # Non-retryable exceptions must not be backoff retried; re-raise so the
+          # NonRetryableException middleware can delete the message immediately.
+          raise if NonRetryableException.non_retryable?(e, worker_options['non_retryable_exceptions'])
 
           if retry_intervals.nil? || !handle_failure(sqs_msg, started_at, retry_intervals)
             # Re-raise the exception if the job is not going to be exponential backoff retried.

--- a/lib/shoryuken/middleware/server/non_retryable_exception.rb
+++ b/lib/shoryuken/middleware/server/non_retryable_exception.rb
@@ -28,6 +28,22 @@ module Shoryuken
       class NonRetryableException
         include Util
 
+        # Checks whether an exception is classified as non-retryable for a worker
+        #
+        # @param exception [Exception] the exception to classify
+        # @param non_retryable_exceptions [Array<Class>, #call, nil] the worker's
+        #   non_retryable_exceptions option: exception classes or a callable
+        # @return [Boolean] true if the exception must not be retried
+        def self.non_retryable?(exception, non_retryable_exceptions)
+          return false unless non_retryable_exceptions
+
+          if non_retryable_exceptions.respond_to?(:call)
+            !!non_retryable_exceptions.call(exception)
+          else
+            Array(non_retryable_exceptions).any? { |klass| exception.is_a?(klass) }
+          end
+        end
+
         # Processes a message and handles non-retryable exceptions
         #
         # @param worker [Object] the worker instance
@@ -41,14 +57,7 @@ module Shoryuken
         rescue => e
           non_retryable_exceptions = worker.class.get_shoryuken_options['non_retryable_exceptions']
 
-          return raise unless non_retryable_exceptions
-
-          if non_retryable_exceptions.respond_to?(:call)
-            return raise unless non_retryable_exceptions.call(e)
-          else
-            exception_classes = Array(non_retryable_exceptions)
-            return raise unless exception_classes.any? { |klass| e.is_a?(klass) }
-          end
+          return raise unless self.class.non_retryable?(e, non_retryable_exceptions)
 
           # Handle batch messages
           messages = sqs_msg.is_a?(Array) ? sqs_msg : [sqs_msg]

--- a/spec/integration/non_retryable_exception/with_retry_intervals_spec.rb
+++ b/spec/integration/non_retryable_exception/with_retry_intervals_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# This spec tests the interplay between non_retryable_exceptions and
+# retry_intervals (exponential backoff) when both are configured on the
+# same worker.
+#
+# Expected behavior: non_retryable_exceptions takes precedence - a message
+# raising a non-retryable exception must be deleted immediately and never
+# retried, while other exceptions still go through the backoff schedule.
+#
+# Regression: ExponentialBackoffRetry sits inside NonRetryableException in
+# the default middleware chain and used to swallow every exception after
+# scheduling a retry, so NonRetryableException never saw non-retryable
+# errors and the message was retried (with the last interval repeated)
+# instead of being deleted.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '2' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+# Exception classes for testing
+PermanentValidationError = Class.new(StandardError)
+TransientNetworkError = Class.new(StandardError)
+
+# Worker with BOTH retry_intervals and non_retryable_exceptions configured
+combined_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true,
+                    batch: false,
+                    retry_intervals: [1, 1],
+                    non_retryable_exceptions: [PermanentValidationError]
+
+  def perform(sqs_msg, body)
+    receive_count = sqs_msg.attributes['ApproximateReceiveCount'].to_i
+    DT[:attempts] << { receive_count: receive_count, body: body, time: Time.now }
+
+    case body
+    when 'non_retryable'
+      raise PermanentValidationError, 'Permanently invalid input'
+    when 'retryable'
+      # Fail on first 2 attempts (covered by retry_intervals), succeed on 3rd
+      raise TransientNetworkError, "Temporary failure on attempt #{receive_count}" if receive_count < 3
+
+      DT[:successful_processing] << { body: body, final_receive_count: receive_count }
+    end
+  end
+end
+
+combined_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, combined_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+begin
+  # Test 1: a non-retryable exception must win over the backoff schedule -
+  # the message is attempted exactly once and deleted, never retried.
+  Shoryuken::Client.sqs.send_message(
+    queue_url: queue_url,
+    message_body: 'non_retryable'
+  )
+
+  Timeout.timeout(10) { sleep 0.5 until DT[:attempts].size >= 1 }
+
+  # Give a buggy retry every chance to happen: with retry_intervals [1, 1]
+  # a swallowed exception would bring the message back after ~1s.
+  sleep 5
+
+  non_retryable_attempts = DT[:attempts].select { |a| a[:body] == 'non_retryable' }
+  assert_equal(
+    1,
+    non_retryable_attempts.size,
+    'Non-retryable exception must not be retried even when retry_intervals is configured ' \
+    "(got #{non_retryable_attempts.size} attempts)"
+  )
+
+  attributes = Shoryuken::Client.sqs.get_queue_attributes(
+    queue_url: queue_url,
+    attribute_names: %w[ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible]
+  ).attributes
+
+  total_messages = attributes['ApproximateNumberOfMessages'].to_i +
+                   attributes['ApproximateNumberOfMessagesNotVisible'].to_i
+  assert_equal(
+    0,
+    total_messages,
+    'Message with non-retryable exception must be deleted immediately, not scheduled for retry'
+  )
+
+  # Test 2: exceptions NOT in the non-retryable list still follow the
+  # backoff schedule and eventually succeed.
+  Shoryuken::Client.sqs.send_message(
+    queue_url: queue_url,
+    message_body: 'retryable'
+  )
+
+  Timeout.timeout(20) { sleep 0.5 until DT[:successful_processing].size >= 1 }
+
+  retryable_attempts = DT[:attempts].select { |a| a[:body] == 'retryable' }
+  assert(retryable_attempts.size >= 3, 'Retryable exception should still go through the backoff schedule')
+  assert_equal('retryable', DT[:successful_processing].first[:body])
+  assert_equal(3, DT[:successful_processing].first[:final_receive_count])
+ensure
+  launcher.stop
+end

--- a/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -94,6 +94,52 @@ RSpec.describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
       end
     end
 
+    context 'and the exception is non-retryable' do
+      it 're-raises so NonRetryableException can delete the message' do
+        TestWorker.get_shoryuken_options['retry_intervals'] = [300, 1800]
+        TestWorker.get_shoryuken_options['non_retryable_exceptions'] = [ArgumentError]
+
+        expect(sqs_msg).not_to receive(:change_visibility)
+
+        expect {
+          subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise ArgumentError, 'permanently invalid' }
+        }.to raise_error(ArgumentError, 'permanently invalid')
+      end
+
+      it 're-raises when a non_retryable_exceptions lambda returns true' do
+        TestWorker.get_shoryuken_options['retry_intervals'] = [300, 1800]
+        TestWorker.get_shoryuken_options['non_retryable_exceptions'] = ->(e) { e.message.include?('permanent') }
+
+        expect(sqs_msg).not_to receive(:change_visibility)
+
+        expect {
+          subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'permanent failure' }
+        }.to raise_error(RuntimeError, 'permanent failure')
+      end
+
+      it 'still retries when a non_retryable_exceptions lambda returns false' do
+        TestWorker.get_shoryuken_options['retry_intervals'] = [300, 1800]
+        TestWorker.get_shoryuken_options['non_retryable_exceptions'] = ->(e) { e.message.include?('permanent') }
+
+        allow(sqs_msg).to receive(:queue) { sqs_queue }
+        expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 300)
+
+        expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'transient failure' } }
+          .not_to raise_error
+      end
+
+      it 'still retries exceptions not in the non-retryable list' do
+        TestWorker.get_shoryuken_options['retry_intervals'] = [300, 1800]
+        TestWorker.get_shoryuken_options['non_retryable_exceptions'] = [ArgumentError]
+
+        allow(sqs_msg).to receive(:queue) { sqs_queue }
+        expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 300)
+
+        expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'transient failure' } }
+          .not_to raise_error
+      end
+    end
+
     it 'limits the visibility timeout to 12 hours' do
       TestWorker.get_shoryuken_options['retry_intervals'] = [86_400]
 


### PR DESCRIPTION
`ExponentialBackoffRetry` sits inside `NonRetryableException` in the default server middleware chain and swallows every exception after scheduling a retry. NonRetryableException therefore never saw non-retryable errors, and poison messages were retried indefinitely (repeating the last interval) instead of being deleted immediately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed retry behavior where non-retryable exceptions were ignored when retry intervals were configured, causing messages to retry indefinitely instead of being deleted immediately.

* **Tests**
  * Added integration and unit tests to verify correct handling of non-retryable exceptions with exponential backoff retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->