### PR TITLE
Fix repeated graceful stop deadlocking the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+- Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
+  - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
+    so a second `Launcher#stop` blocked forever on an empty queue
+  - Operationally this was the TSTP -> USR1 sequence: both signals trigger a graceful stop, leaving
+    the process stuck in the signal loop where even TERM/INT were no longer handled (only SIGKILL worked)
+  - The dispatch loop now closes the signal queue instead of pushing a token, releasing every pending
+    and future waiter; the dispatch chain also releases waiters if the executor rejects a post during
+    a racing hard shutdown
+
 - Fix: `non_retryable_exceptions` is no longer ignored when `retry_intervals` is also configured (mensfeld)
   - `ExponentialBackoffRetry` swallowed every exception after scheduling a retry, so `NonRetryableException`
     (which sits outside it in the default middleware chain) never saw non-retryable errors - poison messages

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -57,6 +57,9 @@ module Shoryuken
       # There might still be a dispatching on-going, as the response from SQS could take some time
       # We don't want to stop the process before processing incoming messages, as they would stay "in-flight" for some time on SQS
       # We use a queue, as the dispatch_loop is running on another thread, and this is a efficient way of communicating between threads.
+      # The dispatch loop closes the queue when it observes the stop flag; pop on a closed queue
+      # returns immediately, so this stays safe when stop is requested more than once
+      # (e.g. TSTP followed by USR1, which both trigger a graceful stop).
       @dispatching_release_signal.pop
     end
 
@@ -74,11 +77,18 @@ module Shoryuken
     # @return [void]
     def dispatch_loop
       if @stop_new_dispatching.true? || !running?
-        @dispatching_release_signal << 1
+        # Close (instead of push) so every pending and future
+        # await_dispatching_in_progress call returns, not just the first one
+        @dispatching_release_signal.close
         return
       end
 
       @executor.post { dispatch }
+    rescue Concurrent::RejectedExecutionError
+      # The executor was shut down between the running? check and the post
+      # (e.g. a hard stop racing the dispatch loop); release any waiters as
+      # the dispatch chain ends here
+      @dispatching_release_signal.close
     end
 
     # Dispatches messages from a queue

--- a/spec/integration/launcher/double_graceful_stop_spec.rb
+++ b/spec/integration/launcher/double_graceful_stop_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# This spec tests that a second graceful stop returns instead of deadlocking.
+#
+# Operationally this is the TSTP -> USR1 sequence: Runner handles TSTP by
+# calling Launcher#stop ("stop accepting new work") and a later USR1 calls
+# Launcher#stop again for the final soft shutdown.
+#
+# Regression: Manager#await_dispatching_in_progress popped a Queue that
+# received exactly one signal when the dispatch loop observed the stop flag.
+# A second Launcher#stop popped an empty queue and blocked forever, leaving
+# the process stuck in the signal loop where even TERM/INT were no longer
+# processed - only SIGKILL could stop it.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+stop_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(_sqs_msg, body)
+    DT[:processed] << body
+  end
+end
+
+stop_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, stop_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+# Prove the launcher is fully up and dispatching before stopping it
+Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'before stop')
+Timeout.timeout(10) { sleep 0.5 until DT[:processed].size >= 1 }
+
+# First graceful stop (TSTP: "stop accepting new work")
+Timeout.timeout(10) { launcher.stop }
+
+# Second graceful stop (USR1 after TSTP: final soft shutdown).
+# This must return promptly instead of blocking forever.
+begin
+  Timeout.timeout(10) { launcher.stop }
+rescue Timeout::Error
+  raise IntegrationsHelper::TestFailure,
+        'Second Launcher#stop deadlocked: await_dispatching_in_progress blocked on an empty signal queue ' \
+        '(TSTP -> USR1 leaves the process unkillable except SIGKILL)'
+end
+
+# Repeated stops must stay safe (idempotent shutdown)
+Timeout.timeout(10) { launcher.stop }
+
+assert_equal(['before stop'], DT[:processed].to_a, 'Message sent before shutdown should have been processed')

--- a/spec/integration/launcher/double_graceful_stop_spec.rb
+++ b/spec/integration/launcher/double_graceful_stop_spec.rb
@@ -41,24 +41,31 @@ queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_ur
 launcher = Shoryuken::Launcher.new
 launcher.start
 
-# Prove the launcher is fully up and dispatching before stopping it
-Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'before stop')
-Timeout.timeout(10) { sleep 0.5 until DT[:processed].size >= 1 }
-
-# First graceful stop (TSTP: "stop accepting new work")
-Timeout.timeout(10) { launcher.stop }
-
-# Second graceful stop (USR1 after TSTP: final soft shutdown).
-# This must return promptly instead of blocking forever.
 begin
+  # Prove the launcher is fully up and dispatching before stopping it
+  Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'before stop')
+  Timeout.timeout(10) { sleep 0.5 until DT[:processed].size >= 1 }
+
+  # First graceful stop (TSTP: "stop accepting new work")
   Timeout.timeout(10) { launcher.stop }
-rescue Timeout::Error
-  raise IntegrationsHelper::TestFailure,
-        'Second Launcher#stop deadlocked: await_dispatching_in_progress blocked on an empty signal queue ' \
-        '(TSTP -> USR1 leaves the process unkillable except SIGKILL)'
+
+  # Second graceful stop (USR1 after TSTP: final soft shutdown).
+  # This must return promptly instead of blocking forever.
+  begin
+    Timeout.timeout(10) { launcher.stop }
+  rescue Timeout::Error
+    raise IntegrationsHelper::TestFailure,
+          'Second Launcher#stop deadlocked: await_dispatching_in_progress blocked on an empty signal queue ' \
+          '(TSTP -> USR1 leaves the process unkillable except SIGKILL)'
+  end
+
+  assert_equal(['before stop'], DT[:processed].to_a, 'Message sent before shutdown should have been processed')
+ensure
+  # Best-effort cleanup so a failure above never leaves a live launcher behind.
+  # On the happy path this is also a third stop, exercising idempotent shutdown.
+  begin
+    Timeout.timeout(10) { launcher.stop }
+  rescue Timeout::Error
+    nil
+  end
 end
-
-# Repeated stops must stay safe (idempotent shutdown)
-Timeout.timeout(10) { launcher.stop }
-
-assert_equal(['before stop'], DT[:processed].to_a, 'Message sent before shutdown should have been processed')

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe Shoryuken::Manager do
     end
   end
 
+  describe '#await_dispatching_in_progress' do
+    it 'returns for repeated graceful stops (e.g. TSTP followed by USR1)' do
+      subject.stop_new_dispatching
+      # The dispatch loop observes the stop flag and releases all waiters
+      subject.start
+
+      waiter = Thread.new do
+        subject.await_dispatching_in_progress
+        subject.await_dispatching_in_progress
+      end
+
+      expect(waiter.join(5)).to eq(waiter), 'await_dispatching_in_progress deadlocked on a repeated stop'
+    end
+  end
+
   describe '#start' do
     before do
       # prevent dispatch loop

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -47,6 +47,24 @@ RSpec.describe Shoryuken::Manager do
 
       expect(waiter.join(5)).to eq(waiter), 'await_dispatching_in_progress deadlocked on a repeated stop'
     end
+
+    context 'when the executor rejects the dispatch post' do
+      let(:executor) do
+        double('executor', running?: true).tap do |rejecting_executor|
+          allow(rejecting_executor).to receive(:post).and_raise(Concurrent::RejectedExecutionError)
+        end
+      end
+
+      it 'releases waiters instead of leaving the signal queue unsignaled' do
+        # A hard stop can shut the executor down between the running? check and
+        # the post; the dispatch chain must still release stop waiters
+        subject.start
+
+        waiter = Thread.new { subject.await_dispatching_in_progress }
+
+        expect(waiter.join(5)).to eq(waiter), 'await_dispatching_in_progress deadlocked after a rejected post'
+      end
+    end
   end
 
   describe '#start' do


### PR DESCRIPTION
Manager#await_dispatching_in_progress popped a signal queue that received exactly one token when the dispatch loop observed the stop flag. A second Launcher#stop popped an empty queue and blocked forever.

Operationally this was the TSTP -> USR1 sequence: Runner handles both signals by calling Launcher#stop, so the second call left the process stuck in the signal loop where even TERM/INT were no longer processed - only SIGKILL could stop it.

The dispatch loop now closes the signal queue instead of pushing a token: pop on a closed queue returns immediately, releasing every pending and future waiter, which makes graceful stop safely repeatable. The dispatch chain also releases waiters if the executor rejects a post during a racing hard shutdown, which previously left the signal queue unsignaled.

Coverage:
- integration spec driving a real launcher through the TSTP -> USR1 double-stop sequence (hung for the full timeout pre-fix)
- unit spec asserting repeated await_dispatching_in_progress calls return after a stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a deadlock that could occur when performing repeated graceful shutdowns so subsequent stop requests complete promptly.
* **Tests**
  * Added integration and unit tests to cover repeated stop behavior and shutdown races, including executor rejection scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->