### PR TITLE
Fix busy-processor double decrement when completion raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+- Fix: Busy-processor accounting no longer breaks when processor completion raises (mensfeld)
+  - `Manager#assign` chained `.then { processor_done }.rescue { processor_done }`, so an exception inside
+    `processor_done` (SQS lookups or a polling strategy's `message_processed` callback) ran completion twice
+  - The busy counter was decremented twice for one message and drifted negative, inflating `ready` and
+    silently breaking the configured concurrency limit for the life of the process
+  - Completion now runs in an `ensure` around processing (exactly once), and `processor_done` logs
+    instead of leaking exceptions from the FIFO bookkeeping
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -139,6 +139,12 @@ module Shoryuken
       return unless @polling_strategy.respond_to?(:message_processed)
 
       @polling_strategy.message_processed(queue)
+    rescue => e
+      # Swallow (but log) failures from the SQS lookups or the strategy callback:
+      # the busy counter was already decremented above and the caller's ensure
+      # must not run completion twice
+      logger.error { "Processor completion failed for #{queue}: #{e.message}" }
+      logger.debug { e.backtrace.join("\n") } unless e.backtrace.nil?
     end
 
     # Assigns a message to a processor
@@ -154,6 +160,11 @@ module Shoryuken
       @busy_processors.increment
       fire_utilization_update_event
 
+      # Completion runs in an ensure so it executes exactly once whether
+      # processing succeeds or raises. The previous `.then { processor_done }
+      # .rescue { processor_done }` chain ran completion twice when
+      # processor_done itself raised, double decrementing the busy counter
+      # and silently breaking the concurrency limit
       Concurrent::Promise
         .execute(executor: @executor) do
           original_priority = Thread.current.priority
@@ -162,10 +173,9 @@ module Shoryuken
             Processor.process(queue_name, sqs_msg)
           ensure
             Thread.current.priority = original_priority
+            processor_done(queue_name)
           end
         end
-        .then { processor_done(queue_name) }
-        .rescue { processor_done(queue_name) }
     end
 
     # Dispatches a batch of messages from a queue

--- a/spec/integration/concurrent_processing/processor_accounting_spec.rb
+++ b/spec/integration/concurrent_processing/processor_accounting_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# This spec tests that the manager's busy-processor accounting stays correct
+# when processor completion handling itself raises.
+#
+# Manager#processor_done makes SQS calls (Shoryuken::Client.queues, #fifo?)
+# and invokes the polling strategy's message_processed callback (a documented
+# extension point) - any of these can raise, e.g. on a transient network
+# error or a bug in a custom strategy.
+#
+# Expected behavior: processor_done runs exactly once per processed message
+# and busy_processors never goes negative, even when processor_done raises.
+#
+# Regression: Manager#assign chained `.then { processor_done }` with
+# `.rescue { processor_done }`, so an exception inside processor_done
+# rejected the then-promise and ran processor_done a SECOND time. The busy
+# counter was decremented twice for one message and drifted negative,
+# inflating `ready` and silently breaking the concurrency limit for the
+# life of the process.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = "#{DT.uuid}.fifo"
+create_fifo_queue(queue_name)
+
+# A custom polling strategy whose message_processed callback raises, like a
+# buggy user strategy or one that performs I/O and hits a transient error.
+# Manager#processor_done invokes it for FIFO queues.
+class FlakyCallbackStrategy < Shoryuken::Polling::WeightedRoundRobin
+  def message_processed(queue)
+    DT[:message_processed_calls] << { queue: queue, time: Time.now }
+    raise 'flaky message_processed callback'
+  end
+end
+
+Shoryuken.add_group('default', 2, polling_strategy: FlakyCallbackStrategy)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+accounting_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(_sqs_msg, body)
+    DT[:processed] << body
+  end
+end
+
+accounting_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, accounting_worker)
+
+# busy_processors is exposed through the public utilization_update event
+Shoryuken.on(:utilization_update) do |opts|
+  DT[:utilization] << opts.dup
+end
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+begin
+  Shoryuken::Client.queues(queue_name).send_message(message_body: 'hello')
+
+  # Wait for the message to be processed and the completion path to run
+  Timeout.timeout(15) { sleep 0.5 until DT[:message_processed_calls].size >= 1 }
+
+  # Give the (buggy) rescue path time to run processor_done a second time
+  sleep 3
+
+  assert_equal(['hello'], DT[:processed].to_a, 'Message should have been processed exactly once')
+
+  assert_equal(
+    1,
+    DT[:message_processed_calls].size,
+    'processor_done must run exactly once per message, even when it raises ' \
+    "(message_processed was called #{DT[:message_processed_calls].size} times)"
+  )
+
+  negative = DT[:utilization].select { |u| u[:busy_processors].negative? }
+  assert(
+    negative.empty?,
+    'busy_processors must never go negative; a double decrement inflates ready ' \
+    "and breaks the concurrency limit (saw: #{negative.first.inspect})"
+  )
+ensure
+  begin
+    Timeout.timeout(10) { launcher.stop }
+  rescue Timeout::Error
+    nil
+  end
+end

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -186,6 +186,44 @@ RSpec.describe Shoryuken::Manager do
     end
   end
 
+  describe '#assign' do
+    let(:sqs_msg) { double(Shoryuken::Message, message_id: SecureRandom.uuid) }
+    let(:sqs_queue) { double(Shoryuken::Queue, fifo?: false) }
+
+    before do
+      allow(Shoryuken::Client).to receive(:queues).with(queue).and_return(sqs_queue)
+      allow(Shoryuken::Processor).to receive(:process)
+    end
+
+    it 'runs completion exactly once on success' do
+      expect(subject).to receive(:processor_done).with(queue).once.and_call_original
+
+      subject.send(:assign, queue, sqs_msg)
+
+      expect(subject.send(:busy)).to eq(0)
+    end
+
+    it 'runs completion exactly once when processing raises' do
+      allow(Shoryuken::Processor).to receive(:process).and_raise('processing failed')
+
+      expect(subject).to receive(:processor_done).with(queue).once.and_call_original
+
+      subject.send(:assign, queue, sqs_msg)
+
+      expect(subject.send(:busy)).to eq(0)
+    end
+
+    it 'does not double decrement the busy counter when completion raises' do
+      allow(sqs_queue).to receive(:fifo?).and_return(true)
+      allow(polling_strategy).to receive(:message_processed).and_raise('callback failed')
+
+      subject.send(:assign, queue, sqs_msg)
+
+      expect(polling_strategy).to have_received(:message_processed).once
+      expect(subject.send(:busy)).to eq(0)
+    end
+  end
+
   describe '#processor_done' do
     let(:sqs_queue)         { double Shoryuken::Queue }
 


### PR DESCRIPTION
Manager#assign chained `.then { processor_done }.rescue { processor_done }` on the processing promise. When processor_done itself raised - via its SQS lookups (Client.queues, fifo?) or a polling strategy's message_processed callback - the then-promise was rejected and the rescue ran processor_done a second time.

Each occurrence decremented the busy counter twice for one message, drifting it negative and inflating `ready` beyond the configured concurrency: the manager over-fetched and queued excess messages on the unbounded executor, silently breaking the concurrency limit for the life of the process.

Completion now runs in an ensure around processing, so it executes exactly once whether processing succeeds or raises. processor_done also logs instead of leaking exceptions from the FIFO bookkeeping, since the counter is already balanced by the time those calls run.

Coverage:
- integration spec with a FIFO queue and a custom polling strategy whose message_processed raises, observing accounting through the public utilization_update event (pre-fix: completion ran twice and busy_processors hit -1)
- unit specs pinning exactly-once completion on success, on processing failure, and balanced counters when completion itself raises

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved processor accounting corruption that occurred when processor completion raised exceptions, preventing the busy processor count from going negative.
  * Message completion logic now runs exactly once per message, eliminating duplicate counter updates.
  * Exceptions during completion are now logged rather than propagating through the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->