### PR TITLE
Fix fatal dispatch error hard-killing an embedded host process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+- Fix: A fatal dispatch error no longer hard-kills an embedded host process (mensfeld)
+  - `Manager#handle_dispatch_error` sent `Process.kill('USR1', Process.pid)` unconditionally after a
+    dispatch error (e.g. SQS still failing once the fetcher exhausted its retries)
+  - The CLI Runner traps USR1 and turns it into a graceful shutdown, but a host embedding
+    `Shoryuken::Launcher` directly has USR1's default disposition, so the whole process - and its
+    in-flight workers - was terminated
+  - When embedded (no CLI Runner), the failing manager now just stops itself and `Launcher#healthy?`
+    reports the failure; the USR1 signal is only sent in server (CLI) mode, preserving the
+    supervisor-restart behavior there
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -218,9 +218,17 @@ module Shoryuken
       logger.error { "Manager failed: #{ex.message}" }
       logger.error { ex.backtrace.join("\n") } unless ex.backtrace.nil?
 
-      Process.kill('USR1', Process.pid)
-
+      # Stop this manager first so Launcher#healthy? surfaces the failure to
+      # whoever is supervising us (the CLI Runner, or an embedding application).
       @running.make_false
+
+      # In server (CLI) mode the Runner traps USR1 and turns it into a graceful
+      # shutdown of the whole process, so a process supervisor can restart us.
+      # When embedded (no Runner), USR1 keeps its default disposition and would
+      # terminate the host process - and any in-flight workers - so we must not
+      # send it. The stopped manager above is enough for Launcher#healthy? to
+      # report the failure to the embedding application.
+      Process.kill('USR1', Process.pid) if Shoryuken.server?
     end
 
     # Fires a utilization update event

--- a/spec/integration/launcher/embedded_dispatch_error_spec.rb
+++ b/spec/integration/launcher/embedded_dispatch_error_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+# This spec tests that a fatal dispatch error does not hard-kill the host
+# process when Shoryuken runs embedded (Launcher used directly, without the
+# CLI Runner).
+#
+# When the dispatch loop hits an unrecoverable error (e.g. SQS still failing
+# after the fetcher exhausts its retries), Manager#handle_dispatch_error used
+# to send Process.kill('USR1', Process.pid) unconditionally. The CLI Runner
+# traps USR1 and turns it into a graceful shutdown, but an embedded host has
+# USR1's default disposition, which terminates the whole process - killing any
+# in-flight workers.
+#
+# Expected behavior when embedded: the failing manager stops itself and
+# Launcher#healthy? reports the failure; no process-killing signal is sent.
+#
+# Regression: embedded mode received an untrapped USR1 and the process died.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+embedded_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(_sqs_msg, _body); end
+end
+
+embedded_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, embedded_worker)
+
+# Force every fetch to fail so the dispatch loop reaches handle_dispatch_error.
+# Prepend (rather than redefine) to avoid method-redefinition warnings.
+failing_fetch = Module.new do
+  def fetch(*)
+    raise 'simulated persistent fetch failure'
+  end
+end
+Shoryuken::Fetcher.prepend(failing_fetch)
+
+# Safely observe whether the process is signalled with USR1. A real embedded
+# host has the default (lethal) disposition; here we trap it only so the test
+# runner survives long enough to assert that the signal is not sent. The trap
+# runs on the main thread, so a plain boolean assignment (no lock, no
+# allocation) is trap-safe and visible to the assertions below.
+usr1_received = false
+previous_handler = Signal.trap('USR1') { usr1_received = true }
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+begin
+  # The failing dispatch should drive the manager - and therefore the launcher -
+  # unhealthy.
+  Timeout.timeout(15) { sleep 0.2 while launcher.healthy? }
+
+  # Give any (buggy) USR1 a chance to be delivered and handled.
+  sleep 1
+
+  refute(
+    usr1_received,
+    'Embedded mode must not send USR1 on a fatal dispatch error: with no Runner ' \
+    'trapping it, the default disposition terminates the host process and its ' \
+    'in-flight workers'
+  )
+
+  assert(!launcher.healthy?, 'Launcher should report unhealthy after a fatal dispatch error')
+ensure
+  Signal.trap('USR1', previous_handler || 'DEFAULT')
+
+  begin
+    Timeout.timeout(10) { launcher.stop }
+  rescue Timeout::Error
+    nil
+  end
+end

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -210,6 +210,34 @@ RSpec.describe Shoryuken::Manager do
     end
   end
 
+  describe '#handle_dispatch_error' do
+    let(:error) { StandardError.new('boom') }
+
+    context 'when running under the CLI (server mode)' do
+      before { allow(Shoryuken).to receive(:server?).and_return(true) }
+
+      it 'stops the manager and signals the process to shut down' do
+        expect(Process).to receive(:kill).with('USR1', Process.pid)
+
+        subject.send(:handle_dispatch_error, error)
+
+        expect(subject.running?).to be false
+      end
+    end
+
+    context 'when embedded (no Runner)' do
+      before { allow(Shoryuken).to receive(:server?).and_return(false) }
+
+      it 'stops the manager without signalling the process' do
+        expect(Process).not_to receive(:kill)
+
+        subject.send(:handle_dispatch_error, error)
+
+        expect(subject.running?).to be false
+      end
+    end
+  end
+
   describe '#running?' do
     context 'when the executor is running' do
       before do


### PR DESCRIPTION
Manager#handle_dispatch_error sent Process.kill('USR1', Process.pid) unconditionally after a dispatch error (e.g. SQS still failing once the fetcher exhausted its retries).

The CLI Runner traps USR1 and turns it into a graceful shutdown so a process supervisor can restart shoryuken. But a host that embeds Shoryuken::Launcher directly has no Runner and so USR1 keeps its default disposition - terminating the whole host process and its in-flight workers.

Now the failing manager always stops itself first (so Launcher#healthy? surfaces the failure), and USR1 is only sent in server (CLI) mode, where the Runner is trapping it. Embedded hosts can poll healthy? and decide how to react instead of being killed. The CLI fail-fast behavior is unchanged.

Coverage:
- integration spec running an embedded launcher with a failing fetcher, trapping USR1 only to assert it is not sent and that the launcher goes unhealthy (pre-fix: USR1 was sent, killing an untrapped host)
- unit specs pinning that handle_dispatch_error signals in server mode and only stops the manager when embedded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fatal dispatch errors no longer force-terminate embedded processes. Manager now gracefully stops and reports failure status, preserving supervisor-restart behavior while maintaining proper shutdown signaling in server mode.

* **Tests**
  * Added integration tests validating error handling in embedded mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->