### PR TITLE
Add timeout-minutes to CI jobs

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         ruby: ['3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
+    # Unit specs finish in under a minute; fail fast instead of letting a
+    # wedged runner occupy the job slot for the 6-hour default
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,6 +32,8 @@ jobs:
       matrix:
         ruby: ['3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
+    # Integration specs normally take ~4 minutes
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -56,6 +61,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: always()
     needs:
       - specs


### PR DESCRIPTION
A wedged runner recently held a Specs job in_progress for 2.5 hours (PR #1006) - without an explicit timeout, GitHub lets such jobs occupy the slot for the 6-hour default before reaping them, and the stuck job blocks the CI Success aggregate and looks like a mysterious spec hang.

Unit specs finish in under a minute and integration specs in about 4 minutes, so 10/15 minute ceilings fail fast with plenty of headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to enforce timeout limits on job execution, preventing extended-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->