### PR TITLE
Fix CurrentAttributes.persist dropping a class across calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Fix: `CurrentAttributes.persist` no longer drops a class when called once per class (mensfeld)
+  - The storage key was derived from the per-call index, so registering classes across separate `persist`
+    calls made the third call reuse `cattr_0` and silently overwrite the second class - its attributes were
+    then never serialized or restored
+  - The key now uses the running registry size, so incremental and single-call registration both yield
+    distinct, stable keys (single-call `persist(A, B, C)` keys are unchanged)
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/active_job/current_attributes.rb
+++ b/lib/shoryuken/active_job/current_attributes.rb
@@ -58,8 +58,12 @@ module Shoryuken
         def persist(*klasses)
           @cattrs ||= {}
 
-          klasses.flatten.each_with_index do |klass, idx|
-            key = @cattrs.empty? ? 'cattr' : "cattr_#{idx}"
+          klasses.flatten.each do |klass|
+            # Key off the running registry size, not the per-call index, so that
+            # registering classes across separate persist calls still produces
+            # distinct keys (a per-call index restarts at 0 each call and would
+            # overwrite earlier registrations).
+            key = @cattrs.empty? ? 'cattr' : "cattr_#{@cattrs.size}"
             @cattrs[key] = klass.to_s
           end
 

--- a/spec/integration/active_job/current_attributes/incremental_persist_spec.rb
+++ b/spec/integration/active_job/current_attributes/incremental_persist_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# CurrentAttributes registered one class per persist call are all preserved.
+#
+# persist derived each storage key from the per-call index, so calling it once
+# per class (as an app might across several initializers) made the third call
+# reuse "cattr_0" and silently overwrite the second class - its attributes were
+# then never serialized or restored.
+
+setup_sqs
+setup_active_job
+
+require 'active_support/current_attributes'
+require 'shoryuken/active_job/current_attributes'
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+
+class CurrentA < ActiveSupport::CurrentAttributes
+  attribute :a_val
+end
+
+class CurrentB < ActiveSupport::CurrentAttributes
+  attribute :b_val
+end
+
+class CurrentC < ActiveSupport::CurrentAttributes
+  attribute :c_val
+end
+
+# Registered incrementally, one class per call.
+Shoryuken::ActiveJob::CurrentAttributes.persist(CurrentA)
+Shoryuken::ActiveJob::CurrentAttributes.persist(CurrentB)
+Shoryuken::ActiveJob::CurrentAttributes.persist(CurrentC)
+
+# Every class must be registered, each under a distinct storage key.
+registered = Shoryuken::ActiveJob::CurrentAttributes.cattrs
+assert_equal(
+  %w[CurrentA CurrentB CurrentC],
+  registered.values.sort,
+  'every persisted CurrentAttributes class must be registered (none silently dropped)'
+)
+assert_equal(3, registered.keys.uniq.size, 'each class must use a distinct storage key')
+
+class IncrementalCurrentJob < ActiveJob::Base
+  def perform
+    DT[:executions] << {
+      a_val: CurrentA.a_val,
+      b_val: CurrentB.b_val,
+      c_val: CurrentC.c_val
+    }
+  end
+end
+
+IncrementalCurrentJob.queue_as(queue_name)
+
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+Shoryuken.register_worker(queue_name, Shoryuken::ActiveJob::JobWrapper)
+
+CurrentA.a_val = 'a-value'
+CurrentB.b_val = 'b-value'
+CurrentC.c_val = 'c-value'
+
+IncrementalCurrentJob.perform_later
+
+CurrentA.reset
+CurrentB.reset
+CurrentC.reset
+
+poll_queues_until(timeout: 30) { DT[:executions].size >= 1 }
+
+result = DT[:executions].first
+assert_equal('a-value', result[:a_val])
+assert_equal('b-value', result[:b_val], 'the second incrementally-persisted class must not be dropped')
+assert_equal('c-value', result[:c_val])


### PR DESCRIPTION
persist derived each storage key from the per-call index ("cattr_#{idx}"). When called one class per call, the index restarted at 0 every call, so the third persist reused "cattr_0" and silently overwrote the second class - its attributes were then never serialized on enqueue or restored on execute.

The key now uses the running registry size, so classes registered across separate persist calls get distinct, stable keys. Single-call persist(A, B, C) produces the same keys as before (cattr, cattr_1, cattr_2), so existing registrations are unaffected.

Coverage:
- integration spec registering three CurrentAttributes classes one per persist call and roundtripping a job through SQS, asserting all three are registered under distinct keys and all values are restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where calling `persist` multiple times on `CurrentAttributes` would overwrite previous registrations, ensuring each call maintains its own distinct storage key.

* **Tests**
  * Added integration test to validate multiple `CurrentAttributes` persist operations work correctly without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->