### PR TITLE
Stop fire_event mutating the lifecycle handler array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+- Fix: Lifecycle events fired in reverse no longer alternate handler order (mensfeld)
+  - `Util#fire_event` reversed the stored handler array in place with `reverse!`, so an event fired more
+    than once with `reverse: true` (e.g. `:shutdown` via `stop` then `stop!`) flipped order each time
+  - It now reverses a copy, leaving the stored handler order untouched
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/util.rb
+++ b/lib/shoryuken/util.rb
@@ -20,7 +20,10 @@ module Shoryuken
     def fire_event(event, reverse = false, event_options = {})
       logger.debug { "Firing '#{event}' lifecycle event" }
       arr = Shoryuken.options[:lifecycle_events][event]
-      arr.reverse! if reverse
+      # reverse (not reverse!) so the stored handler array keeps its original
+      # order: events fired more than once with reverse: true (e.g. :shutdown
+      # via stop then stop!) must not alternate their handler order.
+      arr = arr.reverse if reverse
       arr.each do |block|
         block.call(event_options)
       rescue => e

--- a/spec/lib/shoryuken/util_spec.rb
+++ b/spec/lib/shoryuken/util_spec.rb
@@ -69,5 +69,31 @@ describe 'Shoryuken::Util' do
       expect(value_holder).to receive(:value=).with([:with_options, { my_option: :some_option }])
       subject.fire_event(:some_event, false, my_option: :some_option)
     end
+
+    it 'fires handlers in reverse order consistently across repeated reverse firings' do
+      order = []
+      Shoryuken.options[:lifecycle_events][:some_event] = [
+        ->(_) { order << :a },
+        ->(_) { order << :b },
+        ->(_) { order << :c }
+      ]
+
+      # e.g. :shutdown is fired with reverse: true and can fire more than once
+      # (stop then stop!); every firing must use the same reversed order.
+      subject.fire_event(:some_event, true)
+      subject.fire_event(:some_event, true)
+
+      expect(order).to eq(%i[c b a c b a])
+    end
+
+    it 'does not mutate the stored handler array when firing in reverse' do
+      handlers = [->(_) {}, ->(_) {}]
+      original = handlers.dup
+      Shoryuken.options[:lifecycle_events][:some_event] = handlers
+
+      subject.fire_event(:some_event, true)
+
+      expect(Shoryuken.options[:lifecycle_events][:some_event]).to eq(original)
+    end
   end
 end


### PR DESCRIPTION
Util#fire_event reversed the stored lifecycle_events array in place with reverse! when called with reverse: true. The reversal persisted on the shared array, so an event fired more than once with reverse: true (e.g. :shutdown via stop then stop!) alternated between reversed and original handler order.

It now reverses a copy (arr = arr.reverse), leaving the stored handler order untouched, so every reverse firing uses the same order.

Coverage:
- repeated reverse firings invoke handlers in the same reversed order
- the stored handler array is unchanged after a reverse firing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a bug where reversing lifecycle event firing caused handler execution order to alternate unpredictably across repeated firings. Handlers now execute consistently when fired in reverse, and the original handler configuration remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->