### PR TITLE
Correct retry_intervals exponential backoff documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Docs: Correct the `retry_intervals` exponential backoff documentation (mensfeld)
+  - The `exponential_backoff?` docstring claimed retries stop ("before giving up") after the last configured
+    interval. They do not: once the intervals are exhausted, the last interval is reused for every later
+    attempt, and SQS's redrive policy (maxReceiveCount) is what ultimately moves a message to a dead-letter queue
+  - Added a spec pinning that far-later attempts keep reusing the last interval
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/worker.rb
+++ b/lib/shoryuken/worker.rb
@@ -224,7 +224,11 @@ module Shoryuken
       #
       # @example Configuring exponential backoff
       #   shoryuken_options retry_intervals: [1, 5, 25, 125, 625]
-      #   # Will retry after 1s, 5s, 25s, 125s, then 625s before giving up
+      #   # Retries after 1s, 5s, 25s, 125s, then 625s for every later attempt.
+      #   # Shoryuken does not stop retrying on its own once the intervals are
+      #   # exhausted - it keeps reusing the last interval. Configure an SQS
+      #   # redrive policy (maxReceiveCount) to send exhausted messages to a
+      #   # dead-letter queue.
       #
       # @see #shoryuken_options Documentation for configuring retry_intervals
       def exponential_backoff?

--- a/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
 
         expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
       end
+
+      it 'keeps reusing the last interval for far-later attempts (does not give up)' do
+        TestWorker.get_shoryuken_options['retry_intervals'] = [300, 1800]
+
+        allow(sqs_msg).to receive(:attributes) { { 'ApproximateReceiveCount' => 10 } }
+        allow(sqs_msg).to receive(:queue) { sqs_queue }
+        expect(sqs_msg).to receive(:change_visibility).with(visibility_timeout: 1800)
+
+        expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
+      end
     end
 
     context 'and the exception is non-retryable' do


### PR DESCRIPTION
The exponential_backoff? docstring claimed retries stop ("before giving up") after the last configured interval. They do not: once the intervals are exhausted, get_interval keeps returning the last interval, so the message is retried indefinitely at that cadence. SQS's redrive policy (maxReceiveCount) is what actually moves an exhausted message to a dead-letter queue.

Corrected the docstring to describe the real behavior and added a spec pinning that far-later attempts keep reusing the last interval, so the docs and behavior stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a collision bug in class registration that could cause data overwrites across separate operations.

* **Documentation**
  * Clarified exponential backoff behavior: retry intervals continue indefinitely using the last configured interval until messages are routed to a dead-letter queue via SQS redrive policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->