### PR TITLE
Make polling strategies thread-safe and fix WRR unpause ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+- Fix: Polling strategies are now thread-safe, and WeightedRoundRobin unpauses processed queues reliably (mensfeld)
+  - `message_processed` runs on processor-completion threads (for FIFO queues) while `next_queue`/`messages_found`
+    run on the dispatch thread; they mutate the same state with no synchronization, which is benign on MRI (GVL)
+    but corrupts state on JRuby/TruffleRuby. Both `WeightedRoundRobin` and `StrictPriority` now serialize access
+    with a mutex
+  - `WeightedRoundRobin#unpause_queues` only checked the head of the paused list, so a queue marked ready by
+    `message_processed` could stay stuck behind an earlier-paused queue; it now unpauses the first expired entry
+    anywhere in the list
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/polling/strict_priority.rb
+++ b/lib/shoryuken/polling/strict_priority.rb
@@ -22,6 +22,10 @@ module Shoryuken
                         .each_with_object({}) { |queue, h| h[queue] = Time.at(0) }
 
         @delay = delay
+        # next_queue/messages_found run on the dispatch thread while
+        # message_processed runs on processor-completion threads (for FIFO
+        # queues), so all access to the shared state is serialized.
+        @mutex = Mutex.new
         # Start queues at 0
         reset_next_queue
       end
@@ -30,8 +34,10 @@ module Shoryuken
       #
       # @return [QueueConfiguration, nil] the next queue configuration or nil if all paused
       def next_queue
-        next_queue = next_active_queue
-        next_queue.nil? ? nil : QueueConfiguration.new(next_queue, {})
+        @mutex.synchronize do
+          next_queue = next_active_queue
+          next_queue.nil? ? nil : QueueConfiguration.new(next_queue, {})
+        end
       end
 
       # Handles the result of polling a queue
@@ -40,10 +46,12 @@ module Shoryuken
       # @param messages_found [Integer] number of messages found
       # @return [void]
       def messages_found(queue, messages_found)
-        if messages_found == 0
-          pause(queue)
-        else
-          reset_next_queue
+        @mutex.synchronize do
+          if messages_found == 0
+            pause(queue)
+          else
+            reset_next_queue
+          end
         end
       end
 
@@ -51,11 +59,13 @@ module Shoryuken
       #
       # @return [Array<Array>] array of [queue_name, priority] pairs
       def active_queues
-        @queues
-          .reverse
-          .map.with_index(1)
-          .reject { |q, _| queue_paused?(q) }
-          .reverse
+        @mutex.synchronize do
+          @queues
+            .reverse
+            .map.with_index(1)
+            .reject { |q, _| queue_paused?(q) }
+            .reverse
+        end
       end
 
       # Called when a message from a queue has been processed
@@ -63,9 +73,11 @@ module Shoryuken
       # @param queue [String] the queue name
       # @return [void]
       def message_processed(queue)
-        if queue_paused?(queue)
-          logger.debug "Unpausing #{queue}"
-          @paused_until[queue] = Time.at 0
+        @mutex.synchronize do
+          if queue_paused?(queue)
+            logger.debug "Unpausing #{queue}"
+            @paused_until[queue] = Time.at(0)
+          end
         end
       end
 

--- a/lib/shoryuken/polling/weighted_round_robin.rb
+++ b/lib/shoryuken/polling/weighted_round_robin.rb
@@ -15,18 +15,26 @@ module Shoryuken
         @queues = queues.dup.uniq
         @paused_queues = []
         @delay = delay
+        # next_queue/messages_found run on the dispatch thread while
+        # message_processed runs on processor-completion threads (for FIFO
+        # queues), so all access to the shared state is serialized.
+        @mutex = Mutex.new
       end
 
       # Returns the next queue to poll in round-robin order
       #
       # @return [QueueConfiguration, nil] the next queue configuration or nil if all paused
       def next_queue
-        unpause_queues
-        queue = @queues.shift
-        return nil if queue.nil?
-
-        @queues << queue
-        QueueConfiguration.new(queue, {})
+        @mutex.synchronize do
+          unpause_queues
+          queue = @queues.shift
+          if queue.nil?
+            nil
+          else
+            @queues << queue
+            QueueConfiguration.new(queue, {})
+          end
+        end
       end
 
       # Handles the result of polling a queue, adjusting weight if messages were found
@@ -35,16 +43,17 @@ module Shoryuken
       # @param messages_found [Integer] number of messages found
       # @return [void]
       def messages_found(queue, messages_found)
-        if messages_found == 0
-          pause(queue)
-          return
-        end
-
-        maximum_weight = maximum_queue_weight(queue)
-        current_weight = current_queue_weight(queue)
-        if maximum_weight > current_weight
-          logger.info { "Increasing #{queue} weight to #{current_weight + 1}, max: #{maximum_weight}" }
-          @queues << queue
+        @mutex.synchronize do
+          if messages_found == 0
+            pause(queue)
+          else
+            maximum_weight = maximum_queue_weight(queue)
+            current_weight = current_queue_weight(queue)
+            if maximum_weight > current_weight
+              logger.info { "Increasing #{queue} weight to #{current_weight + 1}, max: #{maximum_weight}" }
+              @queues << queue
+            end
+          end
         end
       end
 
@@ -52,7 +61,7 @@ module Shoryuken
       #
       # @return [Array<Array>] array of [queue_name, weight] pairs
       def active_queues
-        unparse_queues(@queues)
+        @mutex.synchronize { unparse_queues(@queues) }
       end
 
       # Called when a message from a queue has been processed
@@ -60,10 +69,10 @@ module Shoryuken
       # @param queue [String] the queue name
       # @return [void]
       def message_processed(queue)
-        paused_queue = @paused_queues.find { |_time, name| name == queue }
-        return unless paused_queue
-
-        paused_queue[0] = Time.at 0
+        @mutex.synchronize do
+          paused_queue = @paused_queues.find { |_time, name| name == queue }
+          paused_queue[0] = Time.at(0) if paused_queue
+        end
       end
 
       private
@@ -79,16 +88,21 @@ module Shoryuken
         logger.debug "Paused #{queue}"
       end
 
-      # Unpauses queues whose delay has expired
+      # Unpauses the first queue whose delay has expired.
+      #
+      # Scans for any expired entry rather than only the head of the list:
+      # message_processed marks a queue ready by setting its time to the epoch,
+      # and that entry may sit behind an earlier-paused queue that is still
+      # paused - checking only the head would leave the ready queue stuck.
       #
       # @return [void]
       def unpause_queues
-        return if @paused_queues.empty?
-        return if Time.now < @paused_queues.first[0]
+        index = @paused_queues.index { |time, _name| time <= Time.now }
+        return if index.nil?
 
-        pause = @paused_queues.shift
-        @queues << pause[1]
-        logger.debug "Unpaused #{pause[1]}"
+        paused = @paused_queues.delete_at(index)
+        @queues << paused[1]
+        logger.debug "Unpaused #{paused[1]}"
       end
 
       # Returns the current weight of a queue in the active rotation

--- a/spec/lib/shoryuken/polling/strict_priority_spec.rb
+++ b/spec/lib/shoryuken/polling/strict_priority_spec.rb
@@ -155,4 +155,29 @@ RSpec.describe Shoryuken::Polling::StrictPriority do
       expect(strategy.active_queues).to eq([[queue1, 2], [queue2, 1]])
     end
   end
+
+  describe 'thread safety' do
+    it 'serializes concurrent next_queue, messages_found and message_processed' do
+      strategy = Shoryuken::Polling::StrictPriority.new([queue1, queue2], 10)
+
+      errors = []
+      errors_mutex = Mutex.new
+
+      threads = Array.new(6) do
+        Thread.new do
+          50.times do |i|
+            strategy.next_queue
+            strategy.messages_found(queue1, i.even? ? 0 : 1)
+            strategy.message_processed(queue1)
+            strategy.active_queues
+          end
+        rescue => e
+          errors_mutex.synchronize { errors << e }
+        end
+      end
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+    end
+  end
 end

--- a/spec/lib/shoryuken/polling/weighted_round_robin_spec.rb
+++ b/spec/lib/shoryuken/polling/weighted_round_robin_spec.rb
@@ -138,5 +138,55 @@ RSpec.describe Shoryuken::Polling::WeightedRoundRobin do
       expect(subject.next_queue).to eq(queue1) # implicitly unpauses queue2
       expect(subject.active_queues).to eq([[queue1, 2], [queue2, 1]])
     end
+
+    it 'unpauses a processed queue stuck behind an earlier-paused queue' do
+      queues << queue1
+      queues << queue2
+
+      allow(subject).to receive(:delay).and_return(10)
+      now = Time.now
+      allow(Time).to receive(:now).and_return(now)
+
+      subject.messages_found(queue1, 0) # queue1 paused until now + 10
+
+      now += 1
+      allow(Time).to receive(:now).and_return(now)
+      subject.messages_found(queue2, 0) # queue2 paused until now + 10 (after queue1)
+
+      # both queues paused, nothing pollable yet
+      expect(subject.next_queue).to eq(nil)
+
+      # queue2 finishes processing and is marked ready while queue1 is still paused
+      subject.message_processed(queue2)
+
+      # queue2 must be pollable even though the earlier-paused queue1 is still paused
+      expect(subject.next_queue).to eq(queue2)
+    end
+  end
+
+  describe 'thread safety' do
+    it 'serializes concurrent next_queue, messages_found and message_processed' do
+      queues << queue1
+      queues << queue2
+
+      errors = []
+      errors_mutex = Mutex.new
+
+      threads = Array.new(6) do
+        Thread.new do
+          50.times do |i|
+            subject.next_queue
+            subject.messages_found(queue1, i.even? ? 0 : 1)
+            subject.message_processed(queue1)
+            subject.active_queues
+          end
+        rescue => e
+          errors_mutex.synchronize { errors << e }
+        end
+      end
+      threads.each(&:join)
+
+      expect(errors).to be_empty
+    end
   end
 end


### PR DESCRIPTION
message_processed runs on processor-completion threads (for FIFO queues) while next_queue/messages_found run on the dispatch thread. They mutated the same @queues/@paused_queues/@paused_until state with no synchronization - benign on MRI thanks to the GVL, but a genuine corruption risk on JRuby/TruffleRuby. WeightedRoundRobin and StrictPriority now serialize all access to that state with a mutex.

WeightedRoundRobin#unpause_queues also only checked the head of the paused list, so a queue marked ready by message_processed (its time set to the epoch) could stay stuck behind an earlier-paused queue that was still paused. It now unpauses the first expired entry anywhere in the list, preserving the existing head-of-list behaviour for normal pauses.

Coverage:
- deterministic spec: a queue marked processed is pollable even when an earlier-paused queue is still paused (fails before the unpause fix)
- thread-safety smoke tests hammering next_queue/messages_found/ message_processed/active_queues concurrently (the race is invisible on MRI, so these guard the mutex on JRuby/TruffleRuby)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in polling strategies that caused shared state corruption on JRuby/TruffleRuby by implementing thread-safe synchronization.
  * Improved queue unpause logic to prevent queues from getting stuck behind earlier paused entries.

* **Tests**
  * Added comprehensive thread-safety tests for polling strategies to ensure concurrent operation safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->