### PR TITLE
Log every batch-delete failure and return a robust boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Fix: `Queue#delete_messages` now logs every batch-delete failure and returns a robust boolean (mensfeld)
+  - It used `failed.any? { |f| logger.error ... }`, which short-circuited after the first failure - so when
+    a batch had multiple failures only the first was logged - and only returned truthy because `Logger#error`
+    happens to return true (a custom logger returning falsey would have hidden the failure from callers)
+  - It now logs each failure and returns `failed.any?`, so `NonRetryableException`/`AutoDelete` reliably see
+    that some messages may remain and need reprocessing
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -52,11 +52,18 @@ module Shoryuken
       failed_messages = client.delete_message_batch(
         options.merge(queue_url: url)
       ).failed || []
-      failed_messages.any? do |failure|
+
+      # Log every failure (not just the first) and return a plain boolean.
+      # The previous `any? { logger.error ... }` short-circuited after the first
+      # failure - so the rest went unlogged - and only returned truthy because
+      # Logger#error happens to return true.
+      failed_messages.each do |failure|
         logger.error do
           "Could not delete #{failure.id}, code: '#{failure.code}', message: '#{failure.message}', sender_fault: #{failure.sender_fault}"
         end
       end
+
+      failed_messages.any?
     end
 
     # Sends a single message to the queue

--- a/spec/integration/message_operations/partial_batch_delete_spec.rb
+++ b/spec/integration/message_operations/partial_batch_delete_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# This spec exercises Queue#delete_messages against a real partial batch-delete
+# failure (one valid receipt handle plus one invalid one).
+#
+# It confirms the end-to-end contract the NonRetryableException and AutoDelete
+# middlewares rely on: delete_messages returns a plain boolean true when any
+# entry fails, and a partial failure does not abort the rest of the batch (the
+# valid entry is still deleted).
+#
+# Note: the underlying bug (only the first failure was logged, and the truthy
+# return relied on Logger#error returning true) is only observable with a logger
+# that returns falsey, so it is reproduced in the unit specs. With the default
+# logger this path returns true either way - this spec guards the real-SQS
+# behavior of the rewritten method.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+# Send and receive a message so we hold a valid receipt handle.
+Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'keep')
+
+received = []
+Timeout.timeout(15) do
+  loop do
+    received = Shoryuken::Client.sqs.receive_message(
+      queue_url: queue_url, max_number_of_messages: 1, wait_time_seconds: 1
+    ).messages
+    break if received.any?
+  end
+end
+valid_handle = received.first.receipt_handle
+
+# Batch-delete one valid handle and one bogus handle: a partial failure.
+queue = Shoryuken::Client.queues(queue_name)
+result = queue.delete_messages(
+  entries: [
+    { id: '0', receipt_handle: valid_handle },
+    { id: '1', receipt_handle: 'bogus-receipt-handle' }
+  ]
+)
+
+assert_equal(true, result, 'delete_messages should return true when any entry fails to delete')
+
+# The valid entry was still deleted; the partial failure did not abort the batch.
+remaining = nil
+Timeout.timeout(10) do
+  loop do
+    attrs = Shoryuken::Client.sqs.get_queue_attributes(
+      queue_url: queue_url,
+      attribute_names: %w[ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible]
+    ).attributes
+    remaining = attrs['ApproximateNumberOfMessages'].to_i + attrs['ApproximateNumberOfMessagesNotVisible'].to_i
+    break if remaining.zero?
+
+    sleep 0.3
+  end
+end
+
+assert_equal(0, remaining, 'the successfully-deleted message should be gone after the partial failure')

--- a/spec/lib/shoryuken/queue_spec.rb
+++ b/spec/lib/shoryuken/queue_spec.rb
@@ -99,6 +99,43 @@ RSpec.describe Shoryuken::Queue do
 
         subject.delete_messages(entries: entries)
       end
+
+      it 'returns true' do
+        failure = double(id: 'id', code: 'code', message: '...', sender_fault: false)
+        allow(sqs).to receive(:delete_message_batch).and_return(double(failed: [failure]))
+        allow(subject).to receive(:logger).and_return(double('Logger', error: nil))
+
+        expect(subject.delete_messages(entries: entries)).to be true
+      end
+    end
+
+    context 'when several deletes fail' do
+      let(:failures) do
+        [
+          double(id: '1', code: 'c1', message: 'm1', sender_fault: false),
+          double(id: '2', code: 'c2', message: 'm2', sender_fault: true)
+        ]
+      end
+
+      it 'logs every failure, not just the first' do
+        logger = double('Logger')
+        allow(sqs).to receive(:delete_message_batch).and_return(double(failed: failures))
+        allow(subject).to receive(:logger).and_return(logger)
+
+        # Real Logger#error returns true; that truthy return made the old `any?`
+        # short-circuit after the first failure, so the rest went unlogged.
+        expect(logger).to receive(:error).twice.and_return(true)
+
+        subject.delete_messages(entries: entries)
+      end
+    end
+
+    context 'when all deletes succeed' do
+      it 'returns false' do
+        allow(sqs).to receive(:delete_message_batch).and_return(double(failed: []))
+
+        expect(subject.delete_messages(entries: entries)).to be false
+      end
     end
   end
 


### PR DESCRIPTION
Queue#delete_messages used `failed.any? { |f| logger.error ... }`. That had two problems:

- any? short-circuits on the first truthy block result, and Logger#error returns true, so when a batch had multiple failures only the first was ever logged.
- the method's truthy-on-failure return value only worked because Logger#error returns true; a custom logger returning falsey would make delete_messages report success despite failures, hiding from NonRetryableException/AutoDelete that messages may remain.

It now logs each failure with `each` and returns `failed.any?`, a plain boolean independent of the logger.

Coverage:
- unit specs that every failure in a multi-failure batch is logged (not just the first) and that the return value is true on failure even when the logger returns falsey, and false when all deletes succeed
- integration spec exercising a real partial batch-delete failure (valid + invalid receipt handle) end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch message deletion failure logging to capture all failed deletions instead of only the first one
  * Fixed return value behavior for batch deletion operations to reliably indicate whether any failures occurred

* **Tests**
  * Added integration and unit tests for batch deletion scenarios with partial failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->