### PR TITLE
Allow opting out of ActiveJob FIFO message deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+- Feature: `Shoryuken.active_job_fifo_message_deduplication` to opt out of FIFO dedup id generation (mensfeld)
+  - For FIFO queues the ActiveJob adapter derives a content-based `message_deduplication_id` from the
+    serialized job minus `job_id`/`enqueued_at` (#457 / #750), so two distinct enqueues of the same job
+    class and arguments within SQS's 5-minute window silently collapse into one - a "skipped message" trap
+  - Set `Shoryuken.active_job_fifo_message_deduplication = false` to stop generating that id, so identical
+    jobs are no longer silently dropped (rely on the queue's content-based deduplication or explicit ids)
+  - Defaults to `true`, preserving the existing behavior; an explicit `message_deduplication_id` is still honored
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/active_job/queue_adapters/shoryuken_adapter.rb
+++ b/lib/active_job/queue_adapters/shoryuken_adapter.rb
@@ -177,9 +177,11 @@ module ActiveJob
           message_attributes: attributes.merge(MESSAGE_ATTRIBUTES)
         }
 
-        if queue.fifo?
+        if queue.fifo? && Shoryuken.active_job_fifo_message_deduplication?
           # See https://github.com/ruby-shoryuken/shoryuken/issues/457 and
           # https://github.com/ruby-shoryuken/shoryuken/pull/750#issuecomment-1781317929
+          # Disable via Shoryuken.active_job_fifo_message_deduplication = false when distinct
+          # enqueues of the same job class and arguments must not be silently deduplicated.
           msg[:message_deduplication_id] = Digest::SHA256.hexdigest(
             JSON.dump(body.except('job_id', 'enqueued_at'))
           )

--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -58,6 +58,8 @@ module Shoryuken
     :stop_callback=,
     :active_job_queue_name_prefixing?,
     :active_job_queue_name_prefixing=,
+    :active_job_fifo_message_deduplication?,
+    :active_job_fifo_message_deduplication=,
     :sqs_client,
     :sqs_client=,
     :sqs_client_receive_message_opts,

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -34,7 +34,8 @@ module Shoryuken
     # @return [Class] the executor class for running workers
     # @return [Shoryuken::WorkerRegistry] the registry for worker classes
     # @return [Array<#call>] handlers for processing exceptions
-    attr_accessor :active_job_queue_name_prefixing, :cache_visibility_timeout,
+    attr_accessor :active_job_queue_name_prefixing, :active_job_fifo_message_deduplication,
+                  :cache_visibility_timeout,
                   :groups, :launcher_executor, :reloader, :enable_reloading,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry,
                   :exception_handlers
@@ -53,6 +54,7 @@ module Shoryuken
       self.worker_registry = DefaultWorkerRegistry.new
       self.exception_handlers = [DefaultExceptionHandler]
       self.active_job_queue_name_prefixing = false
+      self.active_job_fifo_message_deduplication = true
       self.worker_executor = Worker::DefaultExecutor
       self.cache_visibility_timeout = false
       self.reloader = proc { |&block| block.call }
@@ -300,6 +302,15 @@ module Shoryuken
     # @return [Boolean] true if prefixing is enabled
     def active_job_queue_name_prefixing?
       @active_job_queue_name_prefixing
+    end
+
+    # Checks if the ActiveJob adapter should auto-generate a content-based
+    # message_deduplication_id for FIFO queues. When disabled, distinct enqueues
+    # of the same job class and arguments are no longer silently deduplicated.
+    #
+    # @return [Boolean] true if FIFO deduplication id generation is enabled
+    def active_job_fifo_message_deduplication?
+      @active_job_fifo_message_deduplication
     end
 
     private

--- a/spec/integration/active_job/fifo_dedup_opt_out/fifo_dedup_opt_out_spec.rb
+++ b/spec/integration/active_job/fifo_dedup_opt_out/fifo_dedup_opt_out_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+# This spec tests opting out of the automatic FIFO message_deduplication_id that
+# the ActiveJob adapter generates.
+#
+# For FIFO queues the adapter derives a content-based message_deduplication_id
+# from the serialized job minus job_id/enqueued_at (see issues #457 / #750). That
+# means two *distinct* enqueues of the same job class + args within SQS's 5-minute
+# window collapse into one - the second is silently dropped. That is intentional,
+# but it is a "skipped message" trap for users who legitimately enqueue the same
+# work twice.
+#
+# Expected behavior: setting Shoryuken.active_job_fifo_message_deduplication = false
+# stops the adapter from generating the id, so those enqueues are no longer
+# silently deduplicated. The default (true) preserves the existing behavior.
+#
+# Regression: there was no way to disable the auto-generated deduplication id.
+
+setup_active_job
+
+class FifoOptOutJob < ActiveJob::Base
+  queue_as :fifo_opt_out
+
+  def perform(_arg); end
+end
+
+fifo_queue_mock = Object.new
+fifo_queue_mock.define_singleton_method(:fifo?) { true }
+fifo_queue_mock.define_singleton_method(:name) { 'fifo_opt_out.fifo' }
+
+captured = nil
+fifo_queue_mock.define_singleton_method(:send_message) { |params| captured = params }
+
+Shoryuken::Client.define_singleton_method(:queues) { |_queue_name = nil| fifo_queue_mock }
+Shoryuken.define_singleton_method(:register_worker) { |*| nil }
+
+# Default behavior: the adapter sets a content-based dedup id (excluding the
+# per-enqueue job_id/enqueued_at), so two identical jobs would collapse to one.
+FifoOptOutJob.perform_later('same-args')
+
+assert(
+  captured.key?(:message_deduplication_id),
+  'by default a FIFO ActiveJob send gets an auto-generated message_deduplication_id'
+)
+
+body = captured[:message_body]
+expected = Digest::SHA256.hexdigest(JSON.dump(body.except('job_id', 'enqueued_at')))
+assert_equal(expected, captured[:message_deduplication_id])
+
+# Opt-out: with deduplication disabled the adapter no longer sets a dedup id, so
+# distinct enqueues of identical jobs are not silently dropped.
+Shoryuken.active_job_fifo_message_deduplication = false
+captured = nil
+FifoOptOutJob.perform_later('same-args')
+
+refute(
+  captured.key?(:message_deduplication_id),
+  'with deduplication disabled the adapter must not set message_deduplication_id'
+)
+
+# An explicit deduplication id must still be honored even when auto-generation is off.
+captured = nil
+FifoOptOutJob.set(message_deduplication_id: 'explicit-id').perform_later('same-args')
+
+assert_equal('explicit-id', captured[:message_deduplication_id])

--- a/spec/shared_examples_for_active_job.rb
+++ b/spec/shared_examples_for_active_job.rb
@@ -55,6 +55,24 @@ RSpec.shared_examples 'active_job_adapters' do
         subject.enqueue(job)
       end
 
+      context 'when active_job_fifo_message_deduplication is disabled' do
+        before { Shoryuken.active_job_fifo_message_deduplication = false }
+
+        it 'does not set an auto-generated message_deduplication_id' do
+          expect(queue).to receive(:send_message) do |hash|
+            expect(hash).not_to have_key(:message_deduplication_id)
+          end
+          subject.enqueue(job)
+        end
+
+        it 'still honors an explicit message_deduplication_id' do
+          expect(queue).to receive(:send_message) do |hash|
+            expect(hash[:message_deduplication_id]).to eq('explicit-id')
+          end
+          subject.enqueue(job, message_deduplication_id: 'explicit-id')
+        end
+      end
+
       context 'with message_deduplication_id' do
         context 'when message_deduplication_id is specified in options' do
           it 'should enqueue a message with the deduplication_id specified in options' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,7 @@ RSpec.configure do |config|
     TestWorker.get_shoryuken_options['queue'] = 'default'
 
     Shoryuken.active_job_queue_name_prefixing = false
+    Shoryuken.active_job_fifo_message_deduplication = true
 
     Shoryuken.worker_registry.clear
     Shoryuken.register_worker('default', TestWorker)


### PR DESCRIPTION
For FIFO queues the ActiveJob adapter derives a content-based message_deduplication_id from the serialized job minus job_id and enqueued_at (#457 / #750). That intentionally deduplicates retries, but it also means two distinct enqueues of the same job class and arguments within SQS's 5-minute window silently collapse into one - a "skipped message" trap for anyone who legitimately enqueues the same work twice.

Add Shoryuken.active_job_fifo_message_deduplication (default true, so the current behavior is preserved). Set it to false to stop generating the id, so identical jobs are no longer silently dropped; an explicit message_deduplication_id is still honored.

Coverage:
- integration spec asserting the default still generates the content hash and that disabling it omits the id while honoring an explicit one
- shared-example unit specs (run against both adapters) covering the disabled flag with and without an explicit deduplication id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Shoryuken.active_job_fifo_message_deduplication` configuration flag to control automatic deduplication ID generation for FIFO queues. Enabled by default to maintain backward compatibility. Explicitly provided deduplication IDs are always respected regardless of this setting.

* **Tests**
  * Added integration and shared spec examples covering deduplication opt-out scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->