### PR TITLE
Add wait_for_pending_sends to drain concurrent enqueues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Feature: `ShoryukenConcurrentSendAdapter#wait_for_pending_sends` to drain in-flight async sends (mensfeld)
+  - The concurrent send adapter enqueues by scheduling the SQS send on a background future and returning
+    immediately, so jobs enqueued shortly before the process exits could be silently dropped
+  - `wait_for_pending_sends(timeout = nil)` blocks until every in-flight send has finished (returning
+    false if the optional timeout elapses first); call it from your shutdown sequence to flush pending sends
+  - In-flight futures are tracked and removed as they resolve, so the set does not grow unbounded
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
+++ b/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter.rb
@@ -27,6 +27,8 @@ module ActiveJob
         super() if defined?(super)
         @success_handler = success_handler
         @error_handler = error_handler
+        @pending_sends = Set.new
+        @pending_sends_mutex = Mutex.new
       end
 
       # Enqueues a job asynchronously
@@ -39,6 +41,34 @@ module ActiveJob
       # @return [Concurrent::Promises::Future] the future representing the async operation
       def enqueue(job, options = {})
         send_concurrently(job, options) { |f_job, f_options| super(f_job, f_options) }
+      end
+
+      # Blocks until all in-flight asynchronous sends have completed.
+      #
+      # Because {#enqueue} schedules the SQS send on a background future and
+      # returns immediately, jobs enqueued shortly before the process exits can
+      # be silently dropped before their send runs. Call this from your shutdown
+      # sequence to flush them.
+      #
+      # @param timeout [Numeric, nil] maximum seconds to wait; nil waits indefinitely
+      # @return [Boolean] true if all pending sends finished, false if the timeout elapsed first
+      def wait_for_pending_sends(timeout = nil)
+        pending = @pending_sends_mutex.synchronize { @pending_sends.to_a }
+        return true if pending.empty?
+
+        if timeout
+          deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+          pending.each do |future|
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            break if remaining <= 0
+
+            future.wait(remaining)
+          end
+        else
+          pending.each(&:wait)
+        end
+
+        pending.all?(&:resolved?)
       end
 
       # Returns the success handler, using a default no-op if not set
@@ -68,10 +98,23 @@ module ActiveJob
       # @yield [job, options] the actual enqueue operation
       # @return [Concurrent::Promises::Future] the future representing the async operation
       def send_concurrently(job, options)
-        Concurrent::Promises
-          .future(job, options) { |f_job, f_options| [yield(f_job, f_options), f_job, f_options] }
-          .then { |send_message_response, f_job, f_options| success_handler.call(send_message_response, f_job, f_options) }
-          .rescue(job, options) { |err, f_job, f_options| error_handler.call(err, f_job, f_options) }
+        future = Concurrent::Promises
+                 .future(job, options) { |f_job, f_options| [yield(f_job, f_options), f_job, f_options] }
+                 .then { |response, f_job, f_options| success_handler.call(response, f_job, f_options) }
+                 .rescue(job, options) { |err, f_job, f_options| error_handler.call(err, f_job, f_options) }
+
+        track_pending_send(future)
+      end
+
+      # Tracks an in-flight send future so {#wait_for_pending_sends} can await it,
+      # removing it once it resolves to keep the set from growing unbounded.
+      #
+      # @param future [Concurrent::Promises::Future] the send future to track
+      # @return [Concurrent::Promises::Future] the same future
+      def track_pending_send(future)
+        @pending_sends_mutex.synchronize { @pending_sends.add(future) }
+        future.on_resolution! { @pending_sends_mutex.synchronize { @pending_sends.delete(future) } }
+        future
       end
     end
   end

--- a/spec/integration/active_job/concurrent_send_drain/concurrent_send_drain_spec.rb
+++ b/spec/integration/active_job/concurrent_send_drain/concurrent_send_drain_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# This spec tests that ShoryukenConcurrentSendAdapter lets callers drain
+# in-flight asynchronous sends before the process exits.
+#
+# The concurrent adapter enqueues by scheduling the SQS send on a background
+# future and returning immediately. Without a way to wait for those futures,
+# jobs enqueued shortly before the process exits can be silently dropped - the
+# send never runs.
+#
+# Expected behavior: #wait_for_pending_sends blocks until every in-flight send
+# has finished (so the job actually reaches SQS), with an optional timeout.
+#
+# Regression: the adapter offered no drain, so in-flight sends could be lost.
+
+require 'timeout'
+require 'active_job/queue_adapters/shoryuken_concurrent_send_adapter'
+
+setup_sqs
+setup_active_job
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+
+# Slow the real SQS send so the async enqueue is provably still in-flight right
+# after perform_later returns - i.e. it would be lost if the process exited now.
+slow_send = Class.new do
+  def call(_options)
+    sleep 1
+    yield
+  ensure
+    DT[:sent] << true
+  end
+end
+
+Shoryuken.client_middleware { |chain| chain.add slow_send }
+
+adapter = ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter.new
+ActiveJob::Base.queue_adapter = adapter
+
+class DrainTestJob < ActiveJob::Base
+  def perform(_payload); end
+end
+
+DrainTestJob.queue_as(queue_name)
+
+DrainTestJob.perform_later('payload')
+
+# The send runs asynchronously; immediately after enqueue it has not happened.
+assert(DT[:sent].empty?, 'send should still be in-flight immediately after perform_later')
+
+# Draining must block until the in-flight send completes.
+assert(
+  adapter.wait_for_pending_sends(15),
+  'wait_for_pending_sends should report that all in-flight sends drained'
+)
+assert_equal(1, DT[:sent].size, 'the in-flight send should have completed during the drain')
+
+# End-to-end: the drained job actually reached SQS.
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+count = nil
+Timeout.timeout(10) do
+  loop do
+    count = Shoryuken::Client.sqs.get_queue_attributes(
+      queue_url: queue_url,
+      attribute_names: ['ApproximateNumberOfMessages']
+    ).attributes['ApproximateNumberOfMessages'].to_i
+    break if count >= 1
+
+    sleep 0.3
+  end
+end
+
+assert_equal(1, count, 'the drained job should be present in SQS')

--- a/spec/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter_spec.rb
+++ b/spec/lib/active_job/queue_adapters/shoryuken_concurrent_send_adapter_spec.rb
@@ -37,4 +37,73 @@ RSpec.describe ActiveJob::QueueAdapters::ShoryukenConcurrentSendAdapter do
       subject.enqueue(job, options)
     end
   end
+
+  describe '#wait_for_pending_sends' do
+    # Use a real async executor (instead of the ImmediateExecutor stubbed above)
+    # so sends are genuinely in-flight and the drain has something to wait for.
+    let(:pool) { Concurrent::FixedThreadPool.new(2) }
+    let(:success_handler) { ->(_response, _job, _options) {} }
+    let(:error_handler) { ->(_error, _job, _options) {} }
+
+    before do
+      allow(Concurrent).to receive(:global_io_executor).and_return(pool)
+      allow(Shoryuken).to receive(:register_worker)
+    end
+
+    after do
+      pool.shutdown
+      pool.wait_for_termination(5)
+    end
+
+    it 'returns true when there are no pending sends' do
+      expect(subject.wait_for_pending_sends(1)).to be true
+    end
+
+    it 'blocks until an in-flight send completes' do
+      completed = Concurrent::AtomicBoolean.new(false)
+      allow(queue).to receive(:send_message) do
+        sleep 0.3
+        completed.make_true
+        true
+      end
+
+      subject.enqueue(job, options)
+
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      expect(subject.wait_for_pending_sends(5)).to be true
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      expect(completed.value).to be true
+      expect(elapsed).to be >= 0.2
+    end
+
+    it 'returns false when sends do not finish within the timeout' do
+      allow(queue).to receive(:send_message) do
+        sleep 2
+        true
+      end
+
+      subject.enqueue(job, options)
+
+      expect(subject.wait_for_pending_sends(0.2)).to be false
+    end
+
+    it 'stops tracking sends once they resolve (no unbounded growth)' do
+      allow(queue).to receive(:send_message).and_return(true)
+
+      3.times { subject.enqueue(job, options) }
+      expect(subject.wait_for_pending_sends(5)).to be true
+
+      # Removal happens on the resolving thread, so poll the mutex-guarded set.
+      mutex = subject.instance_variable_get(:@pending_sends_mutex)
+      set = subject.instance_variable_get(:@pending_sends)
+      50.times do
+        break if mutex.synchronize { set.empty? }
+
+        sleep 0.02
+      end
+
+      expect(mutex.synchronize { set.size }).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
ShoryukenConcurrentSendAdapter enqueues by scheduling the SQS send on a background future and returning immediately. With no way to wait for those futures, jobs enqueued shortly before the process exits could be silently dropped - the send never runs.

The adapter now tracks in-flight send futures (removing each as it resolves, so the set does not grow unbounded) and exposes wait_for_pending_sends(timeout = nil), which blocks until they all finish and returns false if the optional timeout elapses first. Call it from a shutdown hook to flush pending sends.

Coverage:
- integration spec that slows the real SQS send via a client middleware, asserts the send is still in-flight right after perform_later, drains, and confirms the job reached SQS
- unit specs that the drain blocks until an async send completes, honors a timeout, returns true when nothing is pending, and stops tracking resolved sends