### PR TITLE
Stop the launcher destroying the global IO executor

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -24,7 +24,23 @@ jobs:
           bundler-cache: true
 
       - name: Run specs
-        run: bundle exec rake spec
+        run: |
+          bundle exec rake spec &
+          SPEC_PID=$!
+          # Send USR1 after 8 minutes so the thread-dump handler in spec_helper
+          # prints a backtrace before the 10-minute job timeout kills everything.
+          ( sleep 480
+            if kill -0 $SPEC_PID 2>/dev/null; then
+              echo "=== specs still running after 8 minutes — requesting thread dump ==="
+              kill -USR1 $SPEC_PID 2>/dev/null || true
+              sleep 5
+            fi
+          ) &
+          WATCHDOG_PID=$!
+          wait $SPEC_PID
+          EXIT_CODE=$?
+          kill $WATCHDOG_PID 2>/dev/null || true
+          exit $EXIT_CODE
 
   integrations:
     name: Integrations

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -24,6 +24,10 @@ jobs:
           bundler-cache: true
 
       - name: Run specs
+        env:
+          # Use the documentation formatter in CI so the log shows which example
+          # is executing — critical for diagnosing hangs that produce no output.
+          SPEC_OPTS: '--format documentation'
         run: |
           bundle exec rake spec &
           SPEC_PID=$!

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -24,12 +24,13 @@ jobs:
           bundler-cache: true
 
       - name: Run specs
-        env:
-          # Use the documentation formatter in CI so the log shows which example
-          # is executing — critical for diagnosing hangs that produce no output.
-          SPEC_OPTS: '--format documentation'
         run: |
-          bundle exec rake spec &
+          # Run rspec directly (not via rake) so $SPEC_PID is the ruby process
+          # itself — the USR1 watchdog below sends the signal to that pid, and
+          # spec_helper registers a USR1 handler that prints a thread dump.
+          # Running via 'bundle exec rake spec' would send the signal to rake,
+          # which has no USR1 handler and would crash before the dump appears.
+          bundle exec rspec --format documentation &
           SPEC_PID=$!
           # Send USR1 after 8 minutes so the thread-dump handler in spec_helper
           # prints a backtrace before the 10-minute job timeout kills everything.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## [Unreleased]
 
+- Fix: Stopping the launcher no longer destroys the process-global IO executor (mensfeld)
+  - With no `launcher_executor` configured, `Launcher#executor` fell back to `Concurrent.global_io_executor`,
+    and `Launcher#stop`/`#stop!` call `shutdown` (and `kill`) on it
+  - Shutting down that process-wide pool broke anything else relying on concurrent-ruby's `:io` pool
+    (including Shoryuken's own `ShoryukenConcurrentSendAdapter`) and prevented starting a fresh launcher
+    in the same process
+  - The launcher now owns a dedicated `Concurrent::CachedThreadPool`, so stopping it leaves the global
+    IO executor untouched
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/bin/integrations
+++ b/bin/integrations
@@ -70,21 +70,23 @@ class IntegrationRunner
   def run_specs(specs)
     results = []
 
-    specs.each do |spec|
+    specs.each_with_index do |spec, idx|
+      prefix = "[#{idx + 1}/#{specs.size}]"
+      puts "#{prefix} RUNNING  #{spec[:name]}"
+      $stdout.flush
+
       result = run_spec(spec)
       results << result
 
-      if result[:skipped]
-        print 'S'
-      elsif result[:success]
-        print '.'
-      else
-        print 'F'
-      end
+      elapsed = result[:duration] ? format('%.1fs', result[:duration]) : '?'
+      status  = if result[:skipped] then 'SKIPPED'
+                elsif result[:success] then 'OK     '
+                else                       'FAILED '
+                end
+      puts "#{prefix} #{status} #{spec[:name]} (#{elapsed})"
       $stdout.flush
     end
 
-    puts
     results
   end
 

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -95,9 +95,15 @@ module Shoryuken
 
     # Returns the executor for running async operations
     #
+    # Owns a dedicated executor rather than borrowing Concurrent.global_io_executor:
+    # {#stop} and {#stop!} shut down and kill this executor, and destroying the
+    # process-global pool would break anything else relying on it (including
+    # Shoryuken's own ShoryukenConcurrentSendAdapter) and prevent a fresh launcher
+    # from starting in the same process.
+    #
     # @return [Concurrent::ExecutorService] the executor service
     def executor
-      @_executor ||= Shoryuken.launcher_executor || Concurrent.global_io_executor
+      @_executor ||= Shoryuken.launcher_executor || Concurrent::CachedThreadPool.new(auto_terminate: true)
     end
 
     # Starts all managers in parallel futures

--- a/spec/integration/launcher/global_executor_preserved_spec.rb
+++ b/spec/integration/launcher/global_executor_preserved_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# This spec tests that stopping the launcher does not destroy the process-wide
+# Concurrent.global_io_executor.
+#
+# When no launcher_executor is configured, Launcher#executor used to fall back
+# to Concurrent.global_io_executor - and Launcher#stop / #stop! call
+# executor.shutdown (and kill). That pool is a process-global singleton shared
+# by anything using concurrent-ruby's :io pool (including Shoryuken's own
+# ShoryukenConcurrentSendAdapter), so shutting it down breaks unrelated work and
+# prevents a fresh launcher from being started in the same process.
+#
+# Expected behavior: the launcher owns a dedicated executor, so stopping it
+# leaves the global IO executor untouched.
+#
+# Regression: stopping the launcher shut down/killed the global IO executor.
+
+require 'timeout'
+
+setup_sqs
+
+# Exercise the real default executor path. The integrations helper injects a
+# dedicated pool via launcher_executor; production CLI/embedded use leaves it
+# nil, which is exactly the path that fell back to the global pool.
+Shoryuken.define_singleton_method(:launcher_executor) { nil }
+
+DT.clear
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(_sqs_msg, body)
+    DT[:processed] << body
+  end
+end
+
+worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'hello')
+Timeout.timeout(15) { sleep 0.2 until DT[:processed].size >= 1 }
+
+launcher.stop!
+
+# The process-global IO executor must still be running after the launcher stops.
+assert(
+  Concurrent.global_io_executor.running?,
+  'Launcher must not shut down the process-global IO executor on stop; ' \
+  'other code (including ShoryukenConcurrentSendAdapter) relies on it'
+)
+
+# ...and it must still actually run work scheduled on it.
+result =
+  begin
+    Concurrent::Promises.future_on(Concurrent.global_io_executor) { 42 }.value(5)
+  rescue Concurrent::RejectedExecutionError
+    nil
+  end
+
+assert_equal(
+  42, result,
+  'A task scheduled on the global IO executor after the launcher stops should still run; ' \
+  'the launcher destroyed the shared pool'
+)

--- a/spec/lib/shoryuken/launcher_spec.rb
+++ b/spec/lib/shoryuken/launcher_spec.rb
@@ -130,10 +130,12 @@ RSpec.describe Shoryuken::Launcher do
         allow(first_group_manager).to receive(:stop_new_dispatching)
         allow(second_group_manager).to receive(:stop_new_dispatching)
 
-        expect(Concurrent.global_io_executor).not_to receive(:shutdown)
-        expect(Concurrent.global_io_executor).not_to receive(:kill)
-
         subject.stop!
+
+        # Verify by inspecting state after the call rather than mocking methods
+        # on the process-global singleton: RSpec proxies on a singleton used by
+        # background concurrent-ruby threads can deadlock on Ruby 3.2.
+        expect(Concurrent.global_io_executor).to be_running
       end
     end
   end

--- a/spec/lib/shoryuken/launcher_spec.rb
+++ b/spec/lib/shoryuken/launcher_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe Shoryuken::Launcher do
     end
   end
 
+  describe 'executor ownership' do
+    context 'when no launcher_executor is configured' do
+      before { allow(Shoryuken).to receive(:launcher_executor).and_return(nil) }
+
+      it 'uses a dedicated executor rather than the process-global IO executor' do
+        expect(subject.send(:executor)).not_to be(Concurrent.global_io_executor)
+      end
+
+      it 'does not shut down or kill the global IO executor on stop!' do
+        allow(first_group_manager).to receive(:stop_new_dispatching)
+        allow(second_group_manager).to receive(:stop_new_dispatching)
+
+        expect(Concurrent.global_io_executor).not_to receive(:shutdown)
+        expect(Concurrent.global_io_executor).not_to receive(:kill)
+
+        subject.stop!
+      end
+    end
+  end
+
   describe '#stopping?' do
     it 'returns false by default' do
       expect(subject.stopping?).to be false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,6 +77,24 @@ class TestWorker
   def perform(sqs_msg, body); end
 end
 
+# Emit a full Ruby thread dump when the process receives USR1.  The CI
+# watchdog (specs.yml) sends this signal when unit specs run longer than
+# expected so we can see exactly which thread is stuck without waiting for the
+# job-level timeout to kill the process silently.
+if Signal.list.key?('USR1')
+  Signal.trap('USR1') do
+    # Signal handlers run in a restricted context; use a plain IO write
+    # rather than puts/logger to stay async-signal safe.
+    output = +"\n=== Thread dump (USR1 watchdog) ===\n"
+    Thread.list.each do |t|
+      output << "--- Thread #{t.object_id} [#{t.status}] ---\n"
+      output << ((t.backtrace || ['(no backtrace)']).join("\n")) << "\n"
+    end
+    output << "=== End thread dump ===\n"
+    $stderr.write(output)
+  end
+end
+
 RSpec.configure do |config|
   config.before do
     Shoryuken::Client.class_variable_set :@@queues, {}


### PR DESCRIPTION
With no launcher_executor configured, Launcher#executor fell back to Concurrent.global_io_executor, and Launcher#stop / #stop! call shutdown (and kill) on it. That pool is a process-wide singleton shared by anything using concurrent-ruby's :io pool - including Shoryuken's own ShoryukenConcurrentSendAdapter - so shutting it down broke unrelated work and stopped a fresh launcher from starting in the same process.

The launcher now owns a dedicated Concurrent::CachedThreadPool, so stopping it leaves the global IO executor untouched.

Coverage:
- integration spec that runs the default executor path (launcher_executor nil), processes a message, stops the launcher, and asserts the global IO executor is still running and still runs scheduled work (pre-fix it was shut down)
- unit specs that the default executor is not the global IO executor and that stop! does not shut down or kill it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stopping the launcher no longer shuts down shared process-global concurrency work. The launcher now uses its own dedicated cached thread pool, so `stop`/`stop!` won’t affect other components and won’t block restarting in the same process.
* **Tests**
  * Added integration and unit coverage to verify global executor preservation and that scheduled work still runs after `stop!`.
* **Chores**
  * Improved CI spec runs with watchdog-triggered thread dumps on timeout and clearer, indexed per-spec progress output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->