### PR TITLE
Fix graceful stop blocking forever on a hung worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Fix: Graceful stop is now bounded by the configured timeout (mensfeld)
+  - `Launcher#stop` (the soft shutdown behind USR1/TSTP) called `executor.wait_for_termination` with no
+    argument - an unbounded wait - so a single hung worker blocked shutdown forever
+  - Both `Launcher#stop` and `Launcher#stop!` now share a `shutdown_executor` helper that waits up to
+    `Shoryuken.options[:timeout]` seconds for in-flight workers, then force-kills the executor so the
+    process can exit; the graceful stop still waits for workers, just no longer indefinitely
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/launcher.rb
+++ b/lib/shoryuken/launcher.rb
@@ -43,8 +43,7 @@ module Shoryuken
       # Don't await here so the timeout below is not delayed
       stop_new_dispatching
 
-      executor.shutdown
-      executor.kill unless executor.wait_for_termination(Shoryuken.options[:timeout])
+      shutdown_executor
 
       fire_event(:stopped)
     end
@@ -61,8 +60,7 @@ module Shoryuken
       stop_new_dispatching
       await_dispatching_in_progress
 
-      executor.shutdown
-      executor.wait_for_termination
+      shutdown_executor
 
       fire_event(:stopped)
     end
@@ -91,6 +89,18 @@ module Shoryuken
     # @return [void]
     def await_dispatching_in_progress
       @managers.each(&:await_dispatching_in_progress)
+    end
+
+    # Shuts the executor down, giving in-flight workers up to the configured
+    # timeout to finish before force-killing them so the process can exit.
+    # Used by both the graceful ({#stop}) and immediate ({#stop!}) shutdowns:
+    # a graceful stop still waits for workers, but must not block forever on a
+    # hung one.
+    #
+    # @return [void]
+    def shutdown_executor
+      executor.shutdown
+      executor.kill unless executor.wait_for_termination(Shoryuken.options[:timeout])
     end
 
     # Returns the executor for running async operations

--- a/spec/integration/launcher/graceful_stop_timeout_spec.rb
+++ b/spec/integration/launcher/graceful_stop_timeout_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# This spec tests that a graceful stop is bounded by the configured timeout and
+# does not block forever on a worker that refuses to finish.
+#
+# Launcher#stop (the soft shutdown behind USR1/TSTP) waits for in-flight workers
+# to finish so their messages are not redelivered. It used to call
+# executor.wait_for_termination with no argument - an unbounded wait - so a
+# single hung worker would block the shutdown forever (and, because the signal
+# loop is stuck, leave the process killable only with SIGKILL).
+#
+# Expected behavior: workers get up to Shoryuken.options[:timeout] seconds to
+# finish, after which the executor is killed and stop returns. Launcher#stop!
+# already did this; Launcher#stop should too.
+#
+# Regression: a hung worker hung Launcher#stop indefinitely.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+# Short grace period so the test is fast; the worker hangs well past it.
+Shoryuken.options[:timeout] = 2
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+hanging_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true
+
+  def perform(_sqs_msg, _body)
+    DT[:started] << true
+    # Hang far longer than the grace period to simulate a stuck worker.
+    sleep 60
+  end
+end
+
+hanging_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, hanging_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+launcher = Shoryuken::Launcher.new
+launcher.start
+
+Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'hang')
+
+# Make sure the worker is genuinely in-flight before we stop.
+Timeout.timeout(15) { sleep 0.2 until DT[:started].size >= 1 }
+
+# Graceful stop must return within roughly the grace period, not block for the
+# full 60s the worker sleeps. Allow generous margin over the 2s timeout.
+started_at = Time.now
+begin
+  Timeout.timeout(20) { launcher.stop }
+rescue Timeout::Error
+  raise IntegrationsHelper::TestFailure,
+        'Launcher#stop blocked past the configured timeout on a hung worker: ' \
+        'a graceful stop must bound executor.wait_for_termination and kill the ' \
+        'executor when exceeded (an unbounded wait hangs USR1/TSTP shutdown forever)'
+end
+elapsed = Time.now - started_at
+
+assert(
+  elapsed < 15,
+  "Graceful stop should return shortly after the #{Shoryuken.options[:timeout]}s timeout, " \
+  "took #{elapsed.round(1)}s"
+)

--- a/spec/lib/shoryuken/launcher_spec.rb
+++ b/spec/lib/shoryuken/launcher_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe Shoryuken::Launcher do
       expect(first_group_manager).to have_received(:stop_new_dispatching)
       expect(second_group_manager).to have_received(:stop_new_dispatching)
     end
+
+    it 'bounds the wait for termination by the configured timeout' do
+      allow(executor).to receive(:shutdown)
+      expect(executor).to receive(:wait_for_termination).with(Shoryuken.options[:timeout]).and_return(true)
+      expect(executor).not_to receive(:kill)
+
+      subject.stop
+    end
+
+    it 'kills the executor when workers do not finish within the timeout' do
+      allow(executor).to receive(:shutdown)
+      allow(executor).to receive(:wait_for_termination).and_return(false)
+      expect(executor).to receive(:kill)
+
+      subject.stop
+    end
   end
 
   describe '#stop!' do


### PR DESCRIPTION
Launcher#stop (the soft shutdown behind USR1/TSTP) called executor.wait_for_termination with no argument - an unbounded wait - so a single worker that never finishes blocked the shutdown forever. Once the signal loop is stuck waiting, the process can then only be stopped with SIGKILL.

Launcher#stop! already bounded the wait with Shoryuken.options[:timeout] and killed the executor when exceeded. Both methods now share a shutdown_executor helper with that behavior, so a graceful stop still waits for in-flight workers but force-kills them once the timeout elapses, letting the process exit.

Coverage:
- integration spec running a worker that sleeps past the grace period and asserting launcher.stop returns shortly after the timeout instead of blocking for the worker's full sleep
- unit specs pinning that stop bounds wait_for_termination by the configured timeout and kills the executor when it is exceeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Soft shutdown now bounds graceful termination by the configured timeout setting instead of waiting indefinitely. Workers that do not complete within the grace period are force-killed to allow the process to exit properly.

* **Tests**
  * Added integration tests to guard against soft shutdown timeout regressions.
  * Added unit tests to verify executor shutdown behavior respects timeout limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->