### PR TITLE
Stop auto_visibility_timeout breaking on short visibility timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+- Fix: `auto_visibility_timeout` no longer breaks processing on queues with a short visibility timeout (mensfeld)
+  - `AutoExtendVisibility` scheduled its `TimerTask` at `visibility_timeout - EXTEND_UPFRONT_SECONDS` (5s);
+    when the queue's visibility timeout was `<= 5s` that interval was `<= 0`, so `TimerTask` raised
+    `ArgumentError` before the worker ran and every message failed (and was reprocessed) until it hit a DLQ
+  - The interval is now clamped to half the visibility timeout when it would be non-positive, and the
+    extension is skipped with a clear warning only when the timeout is `<= 0`; the worker always runs
+
 - Fix: Repeated graceful stop no longer deadlocks the process (mensfeld)
   - `Manager#await_dispatching_in_progress` popped a signal queue that received exactly one token,
     so a second `Launcher#stop` blocked forever on an empty queue

--- a/lib/shoryuken/middleware/server/auto_extend_visibility.rb
+++ b/lib/shoryuken/middleware/server/auto_extend_visibility.rb
@@ -48,8 +48,17 @@ module Shoryuken
           # @return [Shoryuken::Helpers::TimerTask] the timer task
           def auto_extend(_worker, queue, sqs_msg, _body)
             queue_visibility_timeout = Shoryuken::Client.queues(queue).visibility_timeout
+            execution_interval = extension_interval(queue_visibility_timeout)
 
-            Shoryuken::Helpers::TimerTask.new(execution_interval: queue_visibility_timeout - EXTEND_UPFRONT_SECONDS) do
+            unless execution_interval
+              logger.warn do
+                "Not auto-extending visibility for #{queue}/#{sqs_msg.message_id}: queue visibility " \
+                "timeout (#{queue_visibility_timeout}s) is too short. Increase it to use auto_visibility_timeout."
+              end
+              return nil
+            end
+
+            Shoryuken::Helpers::TimerTask.new(execution_interval: execution_interval) do
               logger.debug do
                 "Extending message #{queue}/#{sqs_msg.message_id} visibility timeout by #{queue_visibility_timeout}s"
               end
@@ -61,6 +70,25 @@ module Shoryuken
               end
             end
           end
+
+          private
+
+          # Returns a positive interval at which to re-extend the message's
+          # visibility before it expires, or nil when the visibility timeout is
+          # too short to schedule one. Normally this is EXTEND_UPFRONT_SECONDS
+          # before expiry, but for short timeouts (<= EXTEND_UPFRONT_SECONDS) it
+          # falls back to half the timeout so the timer still fires in time
+          # instead of TimerTask raising on a non-positive interval.
+          #
+          # @param visibility_timeout [Integer] the queue's visibility timeout in seconds
+          # @return [Float, Integer, nil] the execution interval, or nil if too short
+          def extension_interval(visibility_timeout)
+            return nil if visibility_timeout <= 0
+
+            interval = visibility_timeout - EXTEND_UPFRONT_SECONDS
+            interval = visibility_timeout / 2.0 if interval <= 0
+            interval
+          end
         end
 
         # Creates and starts a visibility extension timer
@@ -71,7 +99,9 @@ module Shoryuken
         # @param body [Object] the parsed message body
         # @return [Shoryuken::Helpers::TimerTask] the started timer
         def auto_visibility_timer(worker, queue, sqs_msg, body)
-          MessageVisibilityExtender.new.auto_extend(worker, queue, sqs_msg, body).tap(&:execute)
+          timer = MessageVisibilityExtender.new.auto_extend(worker, queue, sqs_msg, body)
+          timer&.execute
+          timer
         end
       end
     end

--- a/spec/integration/auto_extend_visibility/short_visibility_timeout_spec.rb
+++ b/spec/integration/auto_extend_visibility/short_visibility_timeout_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# This spec tests that auto_visibility_timeout still processes messages when the
+# queue's visibility timeout is short (<= EXTEND_UPFRONT_SECONDS).
+#
+# AutoExtendVisibility schedules a TimerTask at execution_interval =
+# visibility_timeout - EXTEND_UPFRONT_SECONDS (5s). When the queue's visibility
+# timeout is <= 5s that interval is <= 0, and TimerTask#initialize raises
+# ArgumentError *before* the worker runs - so every receive fails and the
+# message is reprocessed (and re-fails) until it hits a DLQ.
+#
+# Expected behavior: a short visibility timeout no longer breaks processing; the
+# extension interval is clamped to a positive value and the worker runs normally.
+#
+# Regression: auto_visibility_timeout + a <= 5s queue visibility timeout broke
+# processing entirely.
+
+require 'timeout'
+
+setup_sqs
+
+DT.clear
+
+queue_name = DT.queue
+# 5s visibility timeout -> interval would be 5 - 5 = 0 -> TimerTask raised pre-fix.
+create_test_queue(queue_name, attributes: { 'VisibilityTimeout' => '5' })
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+short_vt_worker = Class.new do
+  include Shoryuken::Worker
+
+  shoryuken_options auto_delete: true, auto_visibility_timeout: true
+
+  def perform(_sqs_msg, body)
+    DT[:processed] << body
+  end
+end
+
+short_vt_worker.get_shoryuken_options['queue'] = queue_name
+Shoryuken.register_worker(queue_name, short_vt_worker)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+Shoryuken::Client.sqs.send_message(queue_url: queue_url, message_body: 'hello')
+
+poll_queues_until(timeout: 20) { DT[:processed].size >= 1 }
+
+assert_equal(
+  ['hello'],
+  DT[:processed].to_a,
+  'auto_visibility_timeout must not break processing on a queue with a short visibility timeout'
+)

--- a/spec/lib/shoryuken/middleware/server/auto_extend_visibility_spec.rb
+++ b/spec/lib/shoryuken/middleware/server/auto_extend_visibility_spec.rb
@@ -114,4 +114,39 @@ RSpec.describe Shoryuken::Middleware::Server::AutoExtendVisibility do
       Runner.new.run_and_sleep(TestWorker.new, queue, sqs_msg, visibility_timeout)
     end
   end
+
+  context 'when the visibility timeout is too short for the upfront margin' do
+    # interval would be visibility_timeout - extend_upfront == 0, which used to
+    # make TimerTask raise before the worker ran.
+    let(:visibility_timeout) { extend_upfront }
+
+    it 'runs the worker instead of raising' do
+      TestWorker.get_shoryuken_options['auto_visibility_timeout'] = true
+      allow(sqs_msg).to receive(:queue) { sqs_queue }
+      allow(sqs_msg).to receive(:message_id).and_return('test-message-id')
+      allow(sqs_msg).to receive(:change_visibility)
+
+      ran = false
+      subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { ran = true }
+
+      expect(ran).to be true
+    end
+  end
+
+  context 'when the visibility timeout is zero' do
+    let(:visibility_timeout) { 0 }
+
+    it 'warns and runs the worker without scheduling an extension' do
+      TestWorker.get_shoryuken_options['auto_visibility_timeout'] = true
+      allow(sqs_msg).to receive(:queue) { sqs_queue }
+      allow(sqs_msg).to receive(:message_id).and_return('test-message-id')
+      expect(sqs_msg).not_to receive(:change_visibility)
+      expect(Shoryuken.logger).to receive(:warn)
+
+      ran = false
+      subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { ran = true }
+
+      expect(ran).to be true
+    end
+  end
 end


### PR DESCRIPTION
AutoExtendVisibility scheduled its TimerTask at
visibility_timeout - EXTEND_UPFRONT_SECONDS (5s). When the queue's visibility timeout was <= 5s that interval was <= 0, so TimerTask#initialize raised ArgumentError before the worker ran - every message failed and was reprocessed (re-failing) until it hit a DLQ.

The extension interval is now clamped to half the visibility timeout when it would be non-positive, so the timer still fires before the message becomes visible again. The extension is skipped with a clear warning only when the visibility timeout is <= 0. Either way the worker now always runs.

Coverage:
- integration spec with a 5s visibility timeout and an auto_visibility_timeout worker, asserting the message is processed (pre-fix it never was - processing crashed before the worker)
- unit specs that a too-short timeout runs the worker instead of raising, and a zero timeout warns and skips the extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very short or zero message visibility timeouts so workers continue processing without errors.
  * Prevented visibility-extension scheduling from failing when the timeout is too small, while logging a warning and skipping extension when needed.

* **Tests**
  * Added coverage for short and zero visibility timeout scenarios to confirm message processing succeeds as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->