### PR TITLE
Fix TimerTask#kill deadlock on Ruby 3.2 under concurrent callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Fix: `TimerTask#kill` no longer deadlocks on Ruby 3.2 under concurrent callers (mensfeld)
+  - `kill` called `@thread.kill` while holding `@mutex`; the timer loop's `ensure` block calls
+    `@mutex.synchronize` to clear `@running`, so on Ruby 3.2 (where `Thread#kill` yields the GVL
+    to the killed thread for cleanup before returning) both threads waited on each other forever
+  - The thread is now killed after the mutex is released, so the ensure block can always acquire it
+
 - Fix: Stopping the launcher no longer destroys the process-global IO executor (mensfeld)
   - With no `launcher_executor` configured, `Launcher#executor` fell back to `Concurrent.global_io_executor`,
     and `Launcher#stop`/`#stop!` call `shutdown` (and `kill`) on it

--- a/lib/shoryuken/helpers/timer_task.rb
+++ b/lib/shoryuken/helpers/timer_task.rb
@@ -42,14 +42,21 @@ module Shoryuken
       #
       # @return [Boolean] true if killed, false if already killed
       def kill
+        thread_to_kill = nil
+
         @mutex.synchronize do
           return false if @killed
 
           @killed = true
           @running = false
-
-          @thread.kill if @thread&.alive?
+          thread_to_kill = @thread
         end
+
+        # Kill the thread AFTER releasing the mutex. The timer loop's ensure
+        # block calls @mutex.synchronize to clear @running; killing the thread
+        # while holding that mutex deadlocks on Ruby 3.2, where Thread#kill
+        # yields the GVL to the killed thread for cleanup before returning.
+        thread_to_kill&.kill if thread_to_kill&.alive?
         true
       end
 


### PR DESCRIPTION
kill called @thread.kill while still holding @mutex. The timer loop's ensure block calls @mutex.synchronize to clear @running, so on Ruby 3.2 (where Thread#kill yields the GVL to the killed thread for cleanup before returning) the killed thread's ensure immediately blocked on the mutex the caller held — both threads waiting on each other forever.

Fix: capture @thread inside synchronize, release the mutex, then kill the captured thread. The ensure block can now always acquire the free mutex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a deadlock issue affecting timer task termination on Ruby 3.2 that could occur during application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->