### PR TITLE
Fix sqs CLI crash sizing message attributes without a scalar value

### DIFF
--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -146,6 +146,13 @@ module Shoryuken
                            value[:string_value].bytesize
                          elsif value[:binary_value]
                            value[:binary_value].bytesize
+                         else
+                           # List-type attributes (string_list_values /
+                           # binary_list_values) carry no scalar value here and
+                           # are intentionally not requeued (see
+                           # normalize_dump_message). Size them as 0 rather than
+                           # crashing the whole batch with `nil + Integer`.
+                           0
                          end
             name_size + data_type_size + value_size
           end


### PR DESCRIPTION
bin/cli/sqs requeue/mv compute each message's payload size via message_size. For a message attribute that has a :data_type but neither :string_value nor :binary_value - e.g. a list-type attribute, whose value normalize_dump_message intentionally drops - value_size was nil and `name_size + data_type_size + value_size` raised
TypeError: nil can't be coerced into Integer, aborting the whole requeue/mv batch.

Default the size of such value-less attributes to 0. Adds a spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message size calculations for SQS payloads when list-style attributes are present.
  * Prevents errors during batch size estimation by safely handling empty or scalar list values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->