### PR TITLE
Stop perform_async from mutating the caller's options hash

### DIFF
--- a/lib/shoryuken/worker/default_executor.rb
+++ b/lib/shoryuken/worker/default_executor.rb
@@ -15,11 +15,17 @@ module Shoryuken
         # @option options [String] :queue override the default queue
         # @return [Aws::SQS::Types::SendMessageResult] the send result
         def perform_async(worker_class, body, options = {})
-          options[:message_attributes] ||= {}
-          options[:message_attributes]['shoryuken_class'] = {
-            string_value: worker_class.to_s,
-            data_type: 'String'
-          }
+          # Work on a copy: callers may reuse the same options hash across
+          # enqueues, and mutating it (deleting :queue, adding :message_body)
+          # would silently reroute or corrupt later jobs. Merge - rather than
+          # mutate - the nested :message_attributes hash for the same reason.
+          options = options.dup
+          options[:message_attributes] = (options[:message_attributes] || {}).merge(
+            'shoryuken_class' => {
+              string_value: worker_class.to_s,
+              data_type: 'String'
+            }
+          )
 
           options[:message_body] = body
 

--- a/lib/shoryuken/worker/inline_executor.rb
+++ b/lib/shoryuken/worker/inline_executor.rb
@@ -15,13 +15,18 @@ module Shoryuken
         # @option options [Hash] :message_attributes custom message attributes
         # @return [Object] the result of the worker's perform method
         def perform_async(worker_class, body, options = {})
+          # Work on a copy so reused/shared options hashes aren't mutated across
+          # calls (deleting :queue would reroute later jobs to the default
+          # queue). Merge - rather than mutate - the nested message_attributes.
+          options = options.dup
           body = JSON.dump(body) if body.is_a?(Hash)
           queue_name = options.delete(:queue) || worker_class.get_shoryuken_options['queue']
-          message_attributes = options.delete(:message_attributes) || {}
-          message_attributes['shoryuken_class'] = {
-            string_value: worker_class.to_s,
-            data_type: 'String'
-          }
+          message_attributes = (options.delete(:message_attributes) || {}).merge(
+            'shoryuken_class' => {
+              string_value: worker_class.to_s,
+              data_type: 'String'
+            }
+          )
 
           sqs_msg = InlineMessage.new(
             body: body,

--- a/spec/lib/shoryuken/worker/default_executor_spec.rb
+++ b/spec/lib/shoryuken/worker/default_executor_spec.rb
@@ -101,5 +101,18 @@ RSpec.describe Shoryuken::Worker::DefaultExecutor do
 
       TestWorker.perform_async('delayed message', queue: new_queue)
     end
+
+    it 'does not mutate the caller-supplied options hash' do
+      allow(sqs_queue).to receive(:send_message)
+
+      options = { queue: queue, message_attributes: { 'custom' => { string_value: 'v', data_type: 'String' } } }
+
+      TestWorker.perform_async('message', options)
+
+      # :queue must not be deleted, :message_body must not be injected, and the
+      # nested message_attributes must not gain shoryuken_class - otherwise a
+      # reused options hash would reroute/corrupt later enqueues.
+      expect(options).to eq(queue: queue, message_attributes: { 'custom' => { string_value: 'v', data_type: 'String' } })
+    end
   end
 end

--- a/spec/lib/shoryuken/worker/inline_executor_spec.rb
+++ b/spec/lib/shoryuken/worker/inline_executor_spec.rb
@@ -25,6 +25,18 @@ RSpec.describe Shoryuken::Worker::InlineExecutor do
 
       TestWorker.perform_async('test', message_attributes: custom_attributes)
     end
+
+    it 'does not mutate the caller-supplied options hash' do
+      allow_any_instance_of(TestWorker).to receive(:perform)
+
+      options = { queue: 'a_queue', message_attributes: { 'custom' => { string_value: 'v', data_type: 'String' } } }
+
+      TestWorker.perform_async('test', options)
+
+      # :queue and :message_attributes must survive intact so a reused options
+      # hash routes later jobs correctly instead of falling back to the default.
+      expect(options).to eq(queue: 'a_queue', message_attributes: { 'custom' => { string_value: 'v', data_type: 'String' } })
+    end
   end
 
   describe '.perform_in' do


### PR DESCRIPTION
DefaultExecutor#perform_async (and InlineExecutor#perform_async) mutated the options hash passed by the caller: deleting :queue, injecting :message_body, and adding shoryuken_class into the nested :message_attributes. Callers that reuse one options hash across enqueues then had :queue stripped after the first call, silently routing later jobs to the worker's default queue.

Operate on a dup and merge (rather than mutate) the nested message_attributes, so the caller's hash is left untouched.