### PR TITLE
Run the visibility-extension timer at normal thread priority

### DIFF
--- a/lib/shoryuken/helpers/timer_task.rb
+++ b/lib/shoryuken/helpers/timer_task.rb
@@ -66,6 +66,16 @@ module Shoryuken
       #
       # @return [void]
       def run_timer_loop
+        # The timer thread inherits the priority of the thread that called
+        # #execute. Shoryuken runs workers at a lowered priority
+        # (Shoryuken.thread_priority, default -1) and starts the
+        # auto-visibility-extension timer from inside that worker thread, so the
+        # timer would otherwise inherit -1. A latency-sensitive timer must not
+        # run below normal priority: under CPU contention a delayed extension can
+        # miss the visibility timeout and let the message be redelivered (double
+        # processed). Reset to normal priority.
+        Thread.current.priority = 0
+
         until @killed
           sleep(@execution_interval)
           break if @killed

--- a/spec/lib/shoryuken/helpers/timer_task_spec.rb
+++ b/spec/lib/shoryuken/helpers/timer_task_spec.rb
@@ -295,4 +295,28 @@ RSpec.describe Shoryuken::Helpers::TimerTask do
       expect(false_count).to eq(4)
     end
   end
+
+  describe 'thread priority' do
+    it 'does not inherit a lowered priority from the creating thread' do
+      observed = ::Queue.new
+
+      # Shoryuken starts the visibility-extension timer from a worker thread
+      # whose priority is lowered to Shoryuken.thread_priority (default -1).
+      # The timer thread must not inherit that lowered priority, otherwise a
+      # delayed extension under load can miss the visibility timeout and let the
+      # message be redelivered (double processed).
+      creator = Thread.new do
+        Thread.current.priority = -1
+        timer = described_class.new(execution_interval: 0.05) do
+          observed << Thread.current.priority
+        end
+        timer.execute
+        sleep(0.15)
+        timer.kill
+      end
+      creator.join
+
+      expect(observed.pop).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
TimerTask#execute starts the timer with Thread.new from the calling thread, so it inherits that thread's priority. Shoryuken runs workers at a lowered priority (Shoryuken.thread_priority, default -1) and starts the auto-visibility-extension timer from inside the worker thread, so the timer inherited -1. Combined with the first extension firing only after sleep(visibility_timeout - 5), a low-priority timer delayed under CPU contention can miss the visibility timeout and let SQS redeliver the still-processing message (double processing).

Reset the timer thread to normal priority (0) at the start of the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer handling so background timer work runs at normal priority, helping avoid delays that could affect time-sensitive visibility behavior.
  * Added coverage to ensure timer threads do not inherit a lowered priority from the thread that starts them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->