### PR TITLE
Harden exponential backoff: clamp visibility >= 0, don't mask origina…

### DIFF
--- a/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
+++ b/lib/shoryuken/middleware/server/exponential_backoff_retry.rb
@@ -69,11 +69,14 @@ module Shoryuken
         #
         # @param interval [Integer] the desired interval
         # @param started_at [Time] when processing started
-        # @return [Integer] the capped visibility timeout
+        # @return [Integer] the capped visibility timeout (never negative)
         def next_visibility_timeout(interval, started_at)
           max_timeout = 43_200 - (Time.now - started_at).ceil - 1
           interval = max_timeout if interval > max_timeout
-          interval.to_i
+          # Never go negative: a job that ran longer than the 12h SQS ceiling
+          # drives max_timeout below zero, and change_message_visibility rejects
+          # a negative timeout. Clamp to 0 (retry as soon as possible) instead.
+          [interval.to_i, 0].max
         end
 
         # Handles a message failure by adjusting visibility timeout
@@ -92,6 +95,14 @@ module Shoryuken
           logger.info { "Message #{sqs_msg.message_id} failed, will be retried in #{interval} seconds" }
 
           true
+        rescue => e
+          # Rescheduling itself failed (e.g. an expired receipt handle, or a
+          # transient SQS error). Don't let that exception escape and mask the
+          # original worker failure - log it and report "not retried" so the
+          # caller re-raises the original error and the message falls back to the
+          # queue's default visibility timeout.
+          logger.warn { "Failed to set backoff visibility timeout for #{sqs_msg.message_id}: #{e.message}" }
+          false
         end
       end
     end

--- a/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
+++ b/spec/lib/shoryuken/middleware/server/exponential_backoff_retry_spec.rb
@@ -158,5 +158,22 @@ RSpec.describe Shoryuken::Middleware::Server::ExponentialBackoffRetry do
 
       expect { subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'failed' } }.not_to raise_error
     end
+
+    it 'never sets a negative visibility timeout for jobs longer than the SQS ceiling' do
+      started_at = Time.now - 43_300 # ran longer than the 12h SQS maximum
+
+      expect(subject.send(:next_visibility_timeout, 300, started_at)).to eq(0)
+    end
+
+    it 'does not mask the original error when rescheduling fails' do
+      TestWorker.get_shoryuken_options['retry_intervals'] = [300]
+
+      # e.g. an expired receipt handle - change_visibility raises
+      allow(sqs_msg).to receive(:change_visibility).and_raise(StandardError, 'visibility boom')
+
+      expect {
+        subject.call(TestWorker.new, queue, sqs_msg, sqs_msg.body) { raise 'original worker error' }
+      }.to raise_error(RuntimeError, 'original worker error')
+    end
   end
 end


### PR DESCRIPTION
…l error

Two defensive fixes in the exponential backoff retry middleware:

1. next_visibility_timeout could return a negative value when a job ran longer than the 12h SQS ceiling (max_timeout goes below zero), and change_message_visibility rejects a negative timeout. Clamp to 0.

2. handle_failure called change_visibility unguarded. If rescheduling raised (e.g. an expired receipt handle), that exception propagated out of the rescue in #call and *masked the original worker error*, hiding the real failure from exception handlers/notifiers. Rescue it, log, and report 'not retried' so the original error is re-raised and the message falls back to the queue's default visibility timeout.