### PR TITLE
Release stop waiters when the dispatch loop never started

### DIFF
--- a/lib/shoryuken/manager.rb
+++ b/lib/shoryuken/manager.rb
@@ -32,6 +32,7 @@ module Shoryuken
       @executor                   = executor
       @running                    = Shoryuken::Helpers::AtomicBoolean.new(true)
       @stop_new_dispatching       = Shoryuken::Helpers::AtomicBoolean.new(false)
+      @dispatch_started           = Shoryuken::Helpers::AtomicBoolean.new(false)
       @dispatching_release_signal = ::Queue.new
     end
 
@@ -48,6 +49,14 @@ module Shoryuken
     # @return [void]
     def stop_new_dispatching
       @stop_new_dispatching.make_true
+
+      # If the dispatch loop never ran (e.g. a stop arrives before the start
+      # Future is scheduled, or in an embedded host whose executor is
+      # saturated), there is no loop to observe the flag and close the release
+      # signal, so await_dispatching_in_progress would block forever. Close it
+      # here in that case. Queue#close is idempotent, so a dispatch_loop that
+      # does start later and closes it again is harmless.
+      @dispatching_release_signal.close unless @dispatch_started.true?
     end
 
     # Waits for any in-progress dispatching to complete
@@ -76,6 +85,11 @@ module Shoryuken
     #
     # @return [void]
     def dispatch_loop
+      # Mark that the loop has run at least once so stop_new_dispatching knows
+      # it can rely on the loop to close the release signal (and otherwise
+      # closes it itself to avoid a deadlock).
+      @dispatch_started.make_true
+
       if @stop_new_dispatching.true? || !running?
         # Close (instead of push) so every pending and future
         # await_dispatching_in_progress call returns, not just the first one

--- a/spec/lib/shoryuken/manager_spec.rb
+++ b/spec/lib/shoryuken/manager_spec.rb
@@ -48,6 +48,17 @@ RSpec.describe Shoryuken::Manager do
       expect(waiter.join(5)).to eq(waiter), 'await_dispatching_in_progress deadlocked on a repeated stop'
     end
 
+    it 'returns when stopped before the dispatch loop ever runs' do
+      # No #start here: the dispatch loop never runs, so there is nothing to
+      # observe the stop flag and close the signal - stop_new_dispatching must
+      # release waiters itself.
+      subject.stop_new_dispatching
+
+      waiter = Thread.new { subject.await_dispatching_in_progress }
+
+      expect(waiter.join(5)).to eq(waiter), 'await_dispatching_in_progress deadlocked when start never ran'
+    end
+
     context 'when the executor rejects the dispatch post' do
       let(:executor) do
         double('executor', running?: true).tap do |rejecting_executor|


### PR DESCRIPTION
await_dispatching_in_progress blocks on a Queue that is only closed from inside dispatch_loop (when it observes the stop flag). If the loop never runs - a graceful stop arriving before the start Future is scheduled, or an embedded host whose executor pool is saturated so manager.start never runs - the signal is never closed and Launcher#stop deadlocks.

Track whether the loop has started; stop_new_dispatching now closes the release signal itself when it hasn't. Queue#close is idempotent, so a loop that does start later and closes it again is harmless.