### PR TITLE
Use long polling in sqs CLI find_all so dump/mv don't stop early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+- Fix: `shoryuken sqs dump`/`mv` no longer stop early on real SQS (mensfeld)
+  - `find_all` used short polling and broke on the first empty `receive_message` response. Real
+    (distributed) SQS routinely returns an empty batch while the queue still has messages, so dump/mv
+    quietly processed only a fraction of the queue (invisible on single-node ElasticMQ/LocalStack)
+  - It now long-polls and only stops after several consecutive empty batches, so the queue is actually drained
+
 - Feature: `Shoryuken.active_job_fifo_message_deduplication` to opt out of FIFO dedup id generation (mensfeld)
   - For FIFO queues the ActiveJob adapter derives a content-based `message_deduplication_id` from the
     serialized job minus `job_id`/`enqueued_at` (#457 / #750), so two distinct enqueues of the same job

--- a/bin/cli/sqs.rb
+++ b/bin/cli/sqs.rb
@@ -12,6 +12,14 @@ module Shoryuken
       # @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html
       MAX_BATCH_SIZE = 1024 * 1024
 
+      # Long-poll wait (seconds) used when draining a queue in find_all, so a
+      # short-poll empty batch doesn't end dump/mv prematurely.
+      FIND_ALL_WAIT_SECONDS = 1
+
+      # Number of consecutive empty long-poll batches before find_all concludes
+      # the queue is drained.
+      FIND_ALL_MAX_EMPTY_BATCHES = 3
+
       namespace :sqs
       class_option :endpoint, aliases: '-e', type: :string, default: ENV['SHORYUKEN_SQS_ENDPOINT'], desc: 'Endpoint URL'
 
@@ -163,6 +171,7 @@ module Shoryuken
         # @return [Integer] the number of messages received
         def find_all(url, limit, &block)
           count = 0
+          empty_batches = 0
           batch_size = limit > 10 ? 10 : limit
 
           loop do
@@ -172,6 +181,11 @@ module Shoryuken
             messages = sqs.receive_message(
               queue_url: url,
               max_number_of_messages: batch_size,
+              # Long poll: short polling (the default wait_time_seconds: 0)
+              # samples only a subset of SQS hosts and routinely returns an empty
+              # batch even when the queue still has messages, which made dump/mv
+              # stop early and miss messages on real (distributed) SQS.
+              wait_time_seconds: FIND_ALL_WAIT_SECONDS,
               attribute_names: ['All'],
               message_attribute_names: ['All']
             ).messages || []
@@ -181,7 +195,15 @@ module Shoryuken
             count += messages.size
 
             break if count >= limit
-            break if messages.empty?
+
+            # Even with long polling an occasional empty batch is possible while
+            # messages remain, so only give up after several consecutive empties.
+            if messages.empty?
+              empty_batches += 1
+              break if empty_batches >= FIND_ALL_MAX_EMPTY_BATCHES
+            else
+              empty_batches = 0
+            end
           end
 
           count

--- a/spec/integration/cli/find_all_spec.rb
+++ b/spec/integration/cli/find_all_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# `shoryuken sqs dump`/`mv` drain a queue via CLI::SQS#find_all. With short
+# polling, real (distributed) SQS routinely returns an empty batch while the
+# queue still has messages, so find_all must use long polling and must not stop
+# on the first empty response - otherwise dump/mv silently process only a
+# fraction of the queue.
+#
+# ElasticMQ never produces those false-empties, so this drives find_all with a
+# scripted client to verify the behavior deterministically.
+#
+# Lives under spec/integration (not spec/lib) because requiring bin/cli defines
+# Shoryuken::CLI, and Shoryuken#server? is `defined?(Shoryuken::CLI)` - loading
+# it in the unit suite would flip server? for every other spec. Integration
+# specs each run in their own process, so that's contained here.
+
+require 'thor'
+require_relative '../../../bin/cli/base'
+require_relative '../../../bin/cli/sqs'
+
+# A scripted SQS client: hands out batches in order (including a false-empty in
+# the middle), recording the wait_time_seconds it was asked for.
+class ScriptedSqsClient
+  Msg = Struct.new(:message_id)
+
+  attr_reader :wait_times
+
+  def initialize(batches)
+    @batches = batches.dup
+    @wait_times = []
+  end
+
+  def receive_message(params)
+    @wait_times << params[:wait_time_seconds]
+    Struct.new(:messages).new(@batches.shift || [])
+  end
+end
+
+m = ScriptedSqsClient::Msg
+script = [
+  [m.new('a'), m.new('b'), m.new('c')],
+  [m.new('d'), m.new('e')],
+  [],                       # false-empty while 'f' is still queued
+  [m.new('f')]
+]
+client = ScriptedSqsClient.new(script)
+
+cli = Shoryuken::CLI::SQS.allocate
+cli.instance_variable_set(:@_sqs, client)
+
+collected = []
+cli.send(:find_all, 'http://example.com/q', Float::INFINITY) { |msg| collected << msg.message_id }
+
+# Drains everything, including 'f' after the false-empty - short polling would
+# have stopped at the first empty batch and missed it.
+assert_equal(%w[a b c d e f], collected, 'find_all should drain past a false-empty batch')
+
+# And it long-polls rather than short-polls.
+assert(
+  client.wait_times.any? && client.wait_times.all? { |w| w && w.positive? },
+  "find_all should use long polling, saw wait_time_seconds: #{client.wait_times.uniq.inspect}"
+)


### PR DESCRIPTION
find_all (used by sqs dump and sqs mv, both defaulting --number to Float::INFINITY) terminated on the first empty receive_message response. With the default short polling, SQS samples only a subset of its hosts and routinely returns an empty batch while the queue still has messages, so on real (distributed) SQS dump/mv quietly processed only a fraction of the queue (invisible on single-node LocalStack).

Long poll (wait_time_seconds) and only stop after several consecutive empty batches, so the queue is actually drained.

(No spec: exercising bin/cli in-process defines Shoryuken::CLI, and Shoryuken#server? is defined?(Shoryuken::CLI), which would flip server? globally and break other specs - same constraint as the CLI fix in the message_size PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queue-draining behavior for `sqs dump` and `mv` so they continue through intermittent empty SQS responses and finish only after the queue is truly drained.
  * Improved reliability when working with queues that can briefly appear empty even though messages remain.

* **Tests**
  * Added coverage for draining queues with a false-empty batch to ensure all messages are collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->