### PR TITLE
Use deterministic bounded backoff for fetch retries

### DIFF
--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -49,17 +49,33 @@ module Shoryuken
       begin
         yield
       rescue => e
-        # Tries to auto retry connectivity errors
+        # Retry transient fetch failures. The rescue is intentionally broad: the
+        # AWS SDK already retries throttling/5xx/networking errors internally, so
+        # whatever surfaces here is uncommon - give it a few bounded attempts
+        # before giving up (which stops the manager so a supervisor can react).
         raise if attempts >= max_attempts
 
         attempts += 1
 
-        logger.debug { "Retrying fetch attempt #{attempts} for #{e.message}" }
+        logger.debug { "Retrying fetch attempt #{attempts}/#{max_attempts} after error: #{e.message}" }
 
-        sleep((1..5).to_a.sample)
+        # Incremental, bounded backoff (1s, 2s, 3s, ...): deterministic and
+        # testable, unlike the previous random 1-5s sleep, and capped because
+        # attempts never exceeds max_attempts.
+        sleep(backoff_interval(attempts))
 
         retry
       end
+    end
+
+    # Backoff interval, in seconds, before the next fetch retry. Grows linearly
+    # with the attempt number and is naturally bounded because attempts never
+    # exceeds max_attempts.
+    #
+    # @param attempts [Integer] the current (1-based) attempt number
+    # @return [Integer] seconds to sleep before retrying
+    def backoff_interval(attempts)
+      attempts
     end
 
     # Receives messages from an SQS queue

--- a/spec/lib/shoryuken/fetcher_spec.rb
+++ b/spec/lib/shoryuken/fetcher_spec.rb
@@ -128,5 +128,42 @@ RSpec.describe Shoryuken::Fetcher do
         end
       end
     end
+
+    context 'when receive_messages fails transiently' do
+      before do
+        allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
+        # Don't actually sleep between retries
+        allow(subject).to receive(:sleep)
+      end
+
+      it 'retries and then succeeds' do
+        calls = 0
+        allow(queue).to receive(:receive_messages) do
+          calls += 1
+          raise 'transient' if calls < 3
+
+          []
+        end
+
+        expect { subject.fetch(queue_config, 1) }.not_to raise_error
+        expect(calls).to eq(3)
+      end
+
+      it 're-raises after exhausting the retries' do
+        allow(queue).to receive(:receive_messages).and_raise('persistent')
+
+        expect { subject.fetch(queue_config, 1) }.to raise_error('persistent')
+      end
+
+      it 'backs off incrementally between attempts (1s, 2s, 3s)' do
+        allow(queue).to receive(:receive_messages).and_raise('persistent')
+
+        expect(subject).to receive(:sleep).with(1).ordered
+        expect(subject).to receive(:sleep).with(2).ordered
+        expect(subject).to receive(:sleep).with(3).ordered
+
+        expect { subject.fetch(queue_config, 1) }.to raise_error('persistent')
+      end
+    end
   end
 end


### PR DESCRIPTION
Fetcher#fetch_with_auto_retry slept for a random 1-5s between retries (sleep((1..5).to_a.sample)) on the dispatch thread. Replace it with an incremental, bounded backoff (1s, 2s, 3s, ... via backoff_interval), which is deterministic, testable, and capped because attempts never exceeds max_attempts. The rescue stays intentionally broad (the AWS SDK already retries throttling/5xx/networking internally), now with an accurate comment and specs covering retry, exhaustion, and the backoff schedule.