### PR TITLE
Reset all registered CurrentAttributes after each job, not just prese…

### DIFF
--- a/lib/shoryuken/active_job/current_attributes.rb
+++ b/lib/shoryuken/active_job/current_attributes.rb
@@ -113,13 +113,10 @@ module Shoryuken
         # @param hash [Hash] the deserialized job data
         # @return [void]
         def perform(sqs_msg, hash)
-          klasses_to_reset = []
-
           CurrentAttributes.cattrs&.each do |key, klass_name|
             next unless hash.key?(key)
 
             klass = klass_name.constantize
-            klasses_to_reset << klass
 
             begin
               attrs = Serializer.deserialize(hash[key])
@@ -135,7 +132,16 @@ module Shoryuken
 
           super
         ensure
-          klasses_to_reset.each(&:reset)
+          # Reset every registered CurrentAttributes class, not only the ones
+          # present in this message. A message without a cattr key (enqueued
+          # before persist was configured, by a different producer, or with an
+          # empty context) would otherwise leave a previous job's values set on a
+          # reused worker thread, leaking context into the next job.
+          CurrentAttributes.cattrs&.each_value do |klass_name|
+            klass_name.constantize.reset
+          rescue => e
+            Shoryuken.logger.warn("Failed to reset CurrentAttributes #{klass_name}: #{e.message}")
+          end
         end
       end
     end

--- a/lib/shoryuken/active_job/current_attributes.rb
+++ b/lib/shoryuken/active_job/current_attributes.rb
@@ -11,7 +11,12 @@ module Shoryuken
     # This ensures that request-scoped context (like current user, tenant, locale)
     # automatically flows from the code that enqueues a job to the job's execution.
     #
-    # Based on Sidekiq's approach to persisting current attributes.
+    # Based on Sidekiq's approach to persisting current attributes, with one
+    # deliberate difference in cleanup: Sidekiq only touches the classes carried
+    # by a job and leaves the general reset to the Rails executor it runs jobs
+    # inside. Shoryuken does not run jobs inside that executor by default, so the
+    # loader resets every registered class after each job itself - see the note
+    # on {Loading#perform}.
     #
     # @example Setup in initializer
     #   require 'shoryuken/active_job/current_attributes'
@@ -132,11 +137,24 @@ module Shoryuken
 
           super
         ensure
-          # Reset every registered CurrentAttributes class, not only the ones
-          # present in this message. A message without a cattr key (enqueued
-          # before persist was configured, by a different producer, or with an
-          # empty context) would otherwise leave a previous job's values set on a
-          # reused worker thread, leaking context into the next job.
+          # Reset every registered CurrentAttributes class after the job - not
+          # only the ones whose key was in this message.
+          #
+          # Why unconditional (and why this differs from Sidekiq): Sidekiq's
+          # loader only touches classes present in the job and relies on the
+          # Rails executor - which it runs every job inside - to reset all
+          # CurrentAttributes between units of work. Shoryuken has no such safety
+          # net: it wraps a job in the reloader/executor only when
+          # `enable_reloading` is set, which is off by default, so nothing else
+          # clears CurrentAttributes between jobs.
+          #
+          # A blanket reset here is therefore the only thing guaranteeing a clean
+          # thread. Resetting only the present keys leaks whenever a value ends up
+          # set during a job whose message carried no cattr key - e.g. the worker
+          # (or code it calls) writes to Current, on a keyless message (empty
+          # context at enqueue, a different producer, or persist configured after
+          # the message was queued). CurrentAttributes are thread-local and the
+          # pool reuses threads, so that value would surface in the next job.
           CurrentAttributes.cattrs&.each_value do |klass_name|
             klass_name.constantize.reset
           rescue => e

--- a/spec/integration/active_job/current_attributes/cross_job_reset_spec.rb
+++ b/spec/integration/active_job/current_attributes/cross_job_reset_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# A message without a CurrentAttributes key must not inherit a previous job's
+# context. Every registered class is reset after each job - even keyless ones -
+# so values set during one job don't leak into the next on a reused worker
+# thread.
+
+setup_sqs
+setup_active_job
+
+require 'active_support/current_attributes'
+require 'shoryuken/active_job/current_attributes'
+
+queue_name = DT.queue
+create_test_queue(queue_name)
+
+class LeakCurrent < ActiveSupport::CurrentAttributes
+  attribute :user_id
+end
+
+Shoryuken::ActiveJob::CurrentAttributes.persist(LeakCurrent)
+
+class CrossJobResetTestJob < ActiveJob::Base
+  def perform
+    # Record what the worker thread sees at the start of the job, then dirty
+    # Current. Without a reset after a keyless job, the second execution on the
+    # same thread would observe 'leaked' instead of nil.
+    DT[:observed] << LeakCurrent.user_id
+    LeakCurrent.user_id = 'leaked'
+  end
+end
+
+CrossJobResetTestJob.queue_as(queue_name)
+
+# Concurrency 1 so the two jobs run sequentially on the same worker thread.
+Shoryuken.add_group('default', 1)
+Shoryuken.add_queue(queue_name, 1, 'default')
+Shoryuken.register_worker(queue_name, Shoryuken::ActiveJob::JobWrapper)
+
+# Enqueued with an empty context, so both messages carry no cattr key.
+CrossJobResetTestJob.perform_later
+CrossJobResetTestJob.perform_later
+
+poll_queues_until(timeout: 30) { DT[:observed].size >= 2 }
+
+assert_equal([nil, nil], DT[:observed].first(2),
+             "CurrentAttributes leaked across jobs: #{DT[:observed].inspect}")


### PR DESCRIPTION
…nt keys

Loading#perform only reset the CurrentAttributes classes whose key was present in the message. A message without a cattr key - enqueued before persist was configured, by a different producer, or with an empty context
- left the registered class unreset, so a value set during one job could leak into the next job on a reused worker thread (CurrentAttributes are thread-local and Shoryuken reuses pool threads).

Reset every registered class in the ensure regardless of which keys the message carried. Covered by an integration spec (process-isolated, where the CurrentAttributes adapter is loaded) that enqueues two keyless jobs and asserts the second doesn't observe the first's context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `CurrentAttributes` state from leaking between consecutive jobs on reused worker threads.
  * Ensured all registered `CurrentAttributes` are reset after each job, even when the message doesn’t include attribute data.
  * Kept attribute restoration behavior in place and continued warning when a class cannot be restored or reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->