### PR TITLE
Keep the FIFO one-at-a-time fetch cap authoritative over queue options

### DIFF
--- a/lib/shoryuken/fetcher.rb
+++ b/lib/shoryuken/fetcher.rb
@@ -72,11 +72,17 @@ module Shoryuken
 
       shoryuken_queue = Shoryuken::Client.queues(queue.name)
 
-      options[:max_number_of_messages]  = max_number_of_messages(shoryuken_queue, limit, options)
       options[:message_attribute_names] = %w[All]
       options[:attribute_names]         = %w[All]
 
+      # Merge per-queue options BEFORE computing the cap so the FIFO
+      # one-at-a-time guard (and FETCH_LIMIT) always win. Computing the cap last
+      # means a queue option of max_number_of_messages can only lower the count,
+      # never raise a non-batch FIFO queue above 1 - which would let SQS return
+      # several messages from the same group and break ordering.
       options.merge!(queue.options)
+
+      options[:max_number_of_messages] = max_number_of_messages(shoryuken_queue, limit, options)
 
       shoryuken_queue.receive_messages(options)
     end

--- a/spec/integration/fifo_ordering/fifo_max_messages_cap_spec.rb
+++ b/spec/integration/fifo_ordering/fifo_max_messages_cap_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# A custom polling strategy can put :max_number_of_messages in the
+# QueueConfiguration options. For a FIFO queue that must never raise the
+# per-receive count above 1: SQS can otherwise return several messages from the
+# same group in one receive, which Shoryuken would hand to separate processor
+# threads and run concurrently / out of order.
+#
+# This drives a real launcher with a strategy that asks for 10 messages per
+# receive and asserts, end-to-end, that the fetcher still caps the FIFO request
+# to 1 (and that the messages are processed in order). The assertion on the
+# requested count is deterministic regardless of how the SQS backend chooses to
+# respond.
+
+require 'delegate'
+
+setup_sqs
+
+# Records the max_number_of_messages Shoryuken actually asks SQS for, then
+# forwards every call unchanged to the real client.
+class RecordingSqsClient < SimpleDelegator
+  def receive_message(params)
+    DT[:receive_max] << params[:max_number_of_messages]
+    __getobj__.receive_message(params)
+  end
+end
+
+Shoryuken::Client.sqs = RecordingSqsClient.new(Shoryuken::Client.sqs)
+
+# Strategy that requests 10 messages per receive via the queue options - the
+# value the FIFO guard must clamp back down to 1.
+class MaxOverridePollingStrategy < Shoryuken::Polling::BaseStrategy
+  def initialize(queues, _delay = nil)
+    @queue = queues.first
+    @paused_until = Time.at(0)
+  end
+
+  def next_queue
+    return nil if Time.now < @paused_until
+
+    Shoryuken::Polling::QueueConfiguration.new(@queue, max_number_of_messages: 10)
+  end
+
+  # Pause briefly on an empty poll so the dispatch loop doesn't busy-spin once
+  # the queue is drained.
+  def messages_found(_queue, count)
+    @paused_until = Time.now + 0.5 if count.zero?
+  end
+
+  def active_queues
+    [[@queue, 1]]
+  end
+end
+
+queue_name = "#{DT.uuid}.fifo"
+create_fifo_queue(queue_name)
+Shoryuken.add_group('default', 1, polling_strategy: MaxOverridePollingStrategy)
+Shoryuken.add_queue(queue_name, 1, 'default')
+
+worker_class = Class.new do
+  include Shoryuken::Worker
+
+  def perform(_sqs_msg, body)
+    DT[:processed] << body
+  end
+end
+worker_class.get_shoryuken_options['queue'] = queue_name
+worker_class.get_shoryuken_options['auto_delete'] = true
+worker_class.get_shoryuken_options['batch'] = false
+Shoryuken.register_worker(queue_name, worker_class)
+
+queue_url = Shoryuken::Client.sqs.get_queue_url(queue_name: queue_name).queue_url
+
+3.times do |i|
+  Shoryuken::Client.sqs.send_message(
+    queue_url: queue_url,
+    message_body: "msg-#{i}",
+    message_group_id: 'group-a',
+    message_deduplication_id: SecureRandom.uuid
+  )
+end
+
+sleep 1
+
+poll_queues_until { DT[:processed].size >= 3 }
+
+# Messages were processed, in order...
+assert_equal(%w[msg-0 msg-1 msg-2], DT[:processed])
+
+# ...and every FIFO receive requested at most one message, even though the
+# strategy asked for ten - the one-at-a-time guard stays authoritative.
+assert(DT[:receive_max].any?, 'expected at least one receive_message call')
+assert(
+  DT[:receive_max].all? { |max| max == 1 },
+  "FIFO receive should cap max_number_of_messages at 1, saw: #{DT[:receive_max].uniq.inspect}"
+)

--- a/spec/lib/shoryuken/fetcher_spec.rb
+++ b/spec/lib/shoryuken/fetcher_spec.rb
@@ -113,6 +113,19 @@ RSpec.describe Shoryuken::Fetcher do
         subject.fetch(queue_config, limit)
       end
 
+      it 'caps at one message even when the queue config requests more' do
+        # A custom polling strategy can put max_number_of_messages in the
+        # QueueConfiguration options; the FIFO one-at-a-time guard must still win
+        # so SQS can't return several messages from the same group.
+        config = Shoryuken::Polling::QueueConfiguration.new(queue_name, max_number_of_messages: 10)
+
+        allow(Shoryuken::Client).to receive(:queues).with(queue_name).and_return(queue)
+        expect(queue).to receive(:receive_messages)
+          .with(hash_including(max_number_of_messages: 1)).and_return([])
+
+        subject.fetch(config, limit)
+      end
+
       context 'with batch=true' do
         it 'polls the provided limit' do
           # see https://github.com/ruby-shoryuken/shoryuken/pull/530


### PR DESCRIPTION
Fetcher#receive_messages computed the FIFO max_number_of_messages cap and THEN did options.merge!(queue.options). A QueueConfiguration carrying max_number_of_messages (a documented options field, reachable via a custom polling strategy) therefore clobbered the cap, letting SQS return several messages from the same group - which Shoryuken fans out to parallel processors, breaking FIFO ordering.

Merge queue options first and compute the cap last, so the FIFO limit=1 (and FETCH_LIMIT) always win: a queue option can only lower the count, never raise a non-batch FIFO queue above one. Built-in strategies pass {} so behaviour is unchanged for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed FIFO queue polling so message fetch limits are always enforced as intended, even if a higher per-queue batch size is configured.
  * Ensured FIFO guards take precedence during receive options construction to prevent multi-message picks from the same group.
* **Tests**
  * Added unit and integration coverage confirming FIFO queues clamp `max_number_of_messages` to 1 and maintain correct ordering under override attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->