### PR TITLE
Allow opting out of content-based FIFO deduplication for raw sends

### DIFF
--- a/lib/shoryuken.rb
+++ b/lib/shoryuken.rb
@@ -60,6 +60,8 @@ module Shoryuken
     :active_job_queue_name_prefixing=,
     :active_job_fifo_message_deduplication?,
     :active_job_fifo_message_deduplication=,
+    :fifo_message_deduplication?,
+    :fifo_message_deduplication=,
     :sqs_client,
     :sqs_client=,
     :sqs_client_receive_message_opts,

--- a/lib/shoryuken/options.rb
+++ b/lib/shoryuken/options.rb
@@ -35,6 +35,7 @@ module Shoryuken
     # @return [Shoryuken::WorkerRegistry] the registry for worker classes
     # @return [Array<#call>] handlers for processing exceptions
     attr_accessor :active_job_queue_name_prefixing, :active_job_fifo_message_deduplication,
+                  :fifo_message_deduplication,
                   :cache_visibility_timeout,
                   :groups, :launcher_executor, :reloader, :enable_reloading,
                   :start_callback, :stop_callback, :worker_executor, :worker_registry,
@@ -55,6 +56,7 @@ module Shoryuken
       self.exception_handlers = [DefaultExceptionHandler]
       self.active_job_queue_name_prefixing = false
       self.active_job_fifo_message_deduplication = true
+      self.fifo_message_deduplication = true
       self.worker_executor = Worker::DefaultExecutor
       self.cache_visibility_timeout = false
       self.reloader = proc { |&block| block.call }
@@ -311,6 +313,18 @@ module Shoryuken
     # @return [Boolean] true if FIFO deduplication id generation is enabled
     def active_job_fifo_message_deduplication?
       @active_job_fifo_message_deduplication
+    end
+
+    # Checks whether Shoryuken auto-generates a content-based
+    # message_deduplication_id for raw FIFO sends (Worker.perform_async,
+    # Queue#send_message / #send_messages). When disabled, distinct sends of an
+    # identical body are no longer silently deduplicated by SQS - you must then
+    # provide a message_deduplication_id yourself or enable
+    # ContentBasedDeduplication on the queue.
+    #
+    # @return [Boolean] true if FIFO deduplication id generation is enabled
+    def fifo_message_deduplication?
+      @fifo_message_deduplication
     end
 
     private

--- a/lib/shoryuken/queue.rb
+++ b/lib/shoryuken/queue.rb
@@ -224,8 +224,16 @@ module Shoryuken
     def add_fifo_attributes!(options)
       return unless fifo?
 
-      options[:message_group_id]         ||= MESSAGE_GROUP_ID
-      options[:message_deduplication_id] ||= Digest::SHA256.hexdigest(options[:message_body].to_s)
+      options[:message_group_id] ||= MESSAGE_GROUP_ID
+
+      # Auto-generate a content-based dedup id unless disabled. With it on, two
+      # sends of an identical body within SQS's 5-minute window are deduplicated
+      # (the second is silently dropped); disable it to send such messages
+      # distinctly (requires an explicit message_deduplication_id or the queue's
+      # ContentBasedDeduplication attribute).
+      if Shoryuken.fifo_message_deduplication?
+        options[:message_deduplication_id] ||= Digest::SHA256.hexdigest(options[:message_body].to_s)
+      end
 
       options
     end

--- a/spec/lib/shoryuken/queue_spec.rb
+++ b/spec/lib/shoryuken/queue_spec.rb
@@ -254,6 +254,22 @@ RSpec.describe Shoryuken::Queue do
           )
         end
       end
+
+      context 'and Shoryuken.fifo_message_deduplication is disabled' do
+        before { Shoryuken.fifo_message_deduplication = false }
+        after { Shoryuken.fifo_message_deduplication = true }
+
+        it 'does not auto-generate a message_deduplication_id' do
+          expect(sqs).to receive(:send_message_batch) do |arg|
+            first_entry = arg[:entries].first
+
+            expect(first_entry[:message_group_id]).to eq described_class::MESSAGE_GROUP_ID
+            expect(first_entry).not_to have_key(:message_deduplication_id)
+          end
+
+          subject.send_messages([{ message_body: 'msg1', message_attributes: { attr: 'attr1' } }])
+        end
+      end
     end
 
     it 'accepts an array of string' do


### PR DESCRIPTION
Queue#add_fifo_attributes! always set message_deduplication_id to a SHA256 of the body when none was provided, so two raw sends of an identical body within SQS's 5-minute window (Worker.perform_async, Queue#send_message/#send_messages) were silently deduplicated - the second dropped. ActiveJob got an opt-out in #1017
(active_job_fifo_message_deduplication) but the raw path had none.

Add the symmetric Shoryuken.fifo_message_deduplication flag (default true, so behaviour is unchanged). When set false, Shoryuken no longer auto-generates the dedup id; callers provide message_deduplication_id themselves or enable ContentBasedDeduplication on the queue.