### PR TITLE
Fix SimpleCov add_filter deprecation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,23 +43,23 @@ Dotenv.load
 unless ENV['SIMPLECOV_DISABLED']
   require 'simplecov'
   SimpleCov.start do
-  add_filter '/spec/'
-  add_filter '/test_workers/'
-  add_filter '/examples/'
-  add_filter '/vendor/'
-  add_filter '/.bundle/'
+  skip '/spec/'
+  skip '/test_workers/'
+  skip '/examples/'
+  skip '/vendor/'
+  skip '/.bundle/'
 
-  add_group 'Library', 'lib/'
-  add_group 'ActiveJob', 'lib/active_job'
-  add_group 'Middleware', 'lib/shoryuken/middleware'
-  add_group 'Polling', 'lib/shoryuken/polling'
-  add_group 'Workers', 'lib/shoryuken/worker'
-  add_group 'Helpers', 'lib/shoryuken/helpers'
+  group 'Library', 'lib/'
+  group 'ActiveJob', 'lib/active_job'
+  group 'Middleware', 'lib/shoryuken/middleware'
+  group 'Polling', 'lib/shoryuken/polling'
+  group 'Workers', 'lib/shoryuken/worker'
+  group 'Helpers', 'lib/shoryuken/helpers'
 
   enable_coverage :branch
 
   minimum_coverage 89
-  minimum_coverage_by_file 60
+  coverage(:line) { minimum_per_file 60 }
   end
 end
 


### PR DESCRIPTION
SimpleCov 1.0.0 (released 2026-07-12) renamed several configuration helpers. The old names still work but now emit deprecation warnings:

  add_filter -> skip   (same arguments, same behavior)
  add_group  -> group  (same arguments, same behavior)

It also deprecated `minimum_coverage_by_file`, whose replacement is the block form `coverage(:line) { minimum_per_file 60 }`. This is an exact equivalent: both resolve to a `{line: 60}` per-file threshold, so the enforced coverage floor is unchanged.

This matters immediately because the suite promotes warnings to errors (see the Warning.process hook at the top of spec/spec_helper.rb, which raises on any warning originating from this repo). The deprecation warnings are attributed to spec_helper.rb itself, so they are raised rather than printed.

There is no committed Gemfile.lock and simplecov is unpinned, so CI (bundler-cache: true) re-resolves it fresh on every run and now picks up 1.0.0. The last CI run predates the 1.0.0 release, which is the only reason the build is still green; the next run would fail. Verified by resolving fresh (simplecov 1.0.0) and running the suite: 543 examples, 0 failures, no deprecation warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated code coverage configuration and organization.
  * Continued enforcing overall coverage of 89% and minimum per-file coverage of 60%.
  * Preserved branch coverage measurement while excluding non-production directories from coverage results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->